### PR TITLE
Add StAX-based GML parser for NLS topographic features

### DIFF
--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/FeatureType.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/FeatureType.java
@@ -1,0 +1,25 @@
+package net.pkhapps.idispatchx.gis.importer.parser;
+
+/**
+ * The four NLS topographic feature types relevant to geocoding.
+ */
+public enum FeatureType {
+
+    KUNTA("Kunta"),
+    TIEVIIVA("Tieviiva"),
+    OSOITEPISTE("Osoitepiste"),
+    PAIKANNIMI("Paikannimi");
+
+    private final String elementName;
+
+    FeatureType(String elementName) {
+        this.elementName = elementName;
+    }
+
+    /**
+     * Returns the GML element local name for this feature type.
+     */
+    public String elementName() {
+        return elementName;
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/FeatureVisitor.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/FeatureVisitor.java
@@ -1,0 +1,32 @@
+package net.pkhapps.idispatchx.gis.importer.parser;
+
+import net.pkhapps.idispatchx.gis.importer.parser.model.KuntaFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.OsoitepisteFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.PaikannimiFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.TieviivaFeature;
+
+/**
+ * Callback interface for receiving parsed GML features from {@link NlsGmlParser}.
+ */
+public interface FeatureVisitor {
+
+    /**
+     * Called when a Kunta (municipality boundary) feature has been parsed.
+     */
+    void onKunta(KuntaFeature feature);
+
+    /**
+     * Called when a Tieviiva (road segment) feature has been parsed.
+     */
+    void onTieviiva(TieviivaFeature feature);
+
+    /**
+     * Called when an Osoitepiste (address point) feature has been parsed.
+     */
+    void onOsoitepiste(OsoitepisteFeature feature);
+
+    /**
+     * Called when a Paikannimi (place name) feature has been parsed.
+     */
+    void onPaikannimi(PaikannimiFeature feature);
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParser.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParser.java
@@ -1,0 +1,347 @@
+package net.pkhapps.idispatchx.gis.importer.parser;
+
+import net.pkhapps.idispatchx.gis.importer.parser.model.KuntaFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.OsoitepisteFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.PaikannimiFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.TieviivaFeature;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * StAX-based parser for NLS (National Land Survey of Finland) topographic GML files.
+ * Extracts four feature types relevant to geocoding: Kunta, Tieviiva, Osoitepiste, and Paikannimi.
+ * <p>
+ * Parsed features are delivered to a {@link FeatureVisitor} callback. Features that cannot be parsed
+ * (e.g., missing required fields) are logged as warnings and skipped.
+ */
+public final class NlsGmlParser {
+
+    private static final Logger log = LoggerFactory.getLogger(NlsGmlParser.class);
+
+    private NlsGmlParser() {
+    }
+
+    /**
+     * Parses all four feature types from the given GML input stream.
+     *
+     * @param input   the GML input stream
+     * @param visitor callback for parsed features
+     * @throws XMLStreamException if the XML is fundamentally malformed
+     */
+    public static void parse(InputStream input, FeatureVisitor visitor) throws XMLStreamException {
+        parse(input, visitor, EnumSet.allOf(FeatureType.class));
+    }
+
+    /**
+     * Parses the specified feature types from the given GML input stream.
+     *
+     * @param input        the GML input stream
+     * @param visitor      callback for parsed features
+     * @param featureTypes the feature types to parse; others are skipped
+     * @throws XMLStreamException if the XML is fundamentally malformed
+     */
+    public static void parse(InputStream input, FeatureVisitor visitor, Set<FeatureType> featureTypes)
+            throws XMLStreamException {
+        var factory = XMLInputFactory.newInstance();
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+
+        var reader = factory.createXMLStreamReader(input);
+        try {
+            while (reader.hasNext()) {
+                int event = reader.next();
+                if (event == XMLStreamConstants.START_ELEMENT) {
+                    var localName = reader.getLocalName();
+                    if (featureTypes.contains(FeatureType.KUNTA) && "Kunta".equals(localName)) {
+                        tryParseKunta(reader, visitor);
+                    } else if (featureTypes.contains(FeatureType.TIEVIIVA) && "Tieviiva".equals(localName)) {
+                        tryParseTieviiva(reader, visitor);
+                    } else if (featureTypes.contains(FeatureType.OSOITEPISTE) && "Osoitepiste".equals(localName)) {
+                        tryParseOsoitepiste(reader, visitor);
+                    } else if (featureTypes.contains(FeatureType.PAIKANNIMI) && "Paikannimi".equals(localName)) {
+                        tryParsePaikannimi(reader, visitor);
+                    }
+                }
+            }
+        } finally {
+            reader.close();
+        }
+    }
+
+    private static void tryParseKunta(XMLStreamReader reader, FeatureVisitor visitor) {
+        try {
+            visitor.onKunta(parseKunta(reader));
+        } catch (Exception e) {
+            log.warn("Failed to parse Kunta feature, skipping: {}", e.getMessage());
+        }
+    }
+
+    private static void tryParseTieviiva(XMLStreamReader reader, FeatureVisitor visitor) {
+        try {
+            visitor.onTieviiva(parseTieviiva(reader));
+        } catch (Exception e) {
+            log.warn("Failed to parse Tieviiva feature, skipping: {}", e.getMessage());
+        }
+    }
+
+    private static void tryParseOsoitepiste(XMLStreamReader reader, FeatureVisitor visitor) {
+        try {
+            visitor.onOsoitepiste(parseOsoitepiste(reader));
+        } catch (Exception e) {
+            log.warn("Failed to parse Osoitepiste feature, skipping: {}", e.getMessage());
+        }
+    }
+
+    private static void tryParsePaikannimi(XMLStreamReader reader, FeatureVisitor visitor) {
+        try {
+            visitor.onPaikannimi(parsePaikannimi(reader));
+        } catch (Exception e) {
+            log.warn("Failed to parse Paikannimi feature, skipping: {}", e.getMessage());
+        }
+    }
+
+    private static KuntaFeature parseKunta(XMLStreamReader reader) throws XMLStreamException {
+        long gid = Long.parseLong(reader.getAttributeValue(null, "gid"));
+        LocalDate alkupvm = null;
+        @Nullable LocalDate loppupvm = null;
+        String kuntatunnus = null;
+        double[][] polygonCoordinates = null;
+
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                switch (reader.getLocalName()) {
+                    case "alkupvm" -> alkupvm = LocalDate.parse(readElementText(reader));
+                    case "loppupvm" -> loppupvm = LocalDate.parse(readElementText(reader));
+                    case "kuntatunnus" -> kuntatunnus = readElementText(reader);
+                    case "Alue" -> polygonCoordinates = parsePosList(reader);
+                    default -> { /* skip */ }
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "Kunta".equals(reader.getLocalName())) {
+                break;
+            }
+        }
+
+        if (alkupvm == null) throw new IllegalStateException("Missing alkupvm");
+        if (kuntatunnus == null) throw new IllegalStateException("Missing kuntatunnus");
+        if (polygonCoordinates == null) throw new IllegalStateException("Missing polygon coordinates");
+
+        return new KuntaFeature(gid, alkupvm, loppupvm, kuntatunnus, polygonCoordinates);
+    }
+
+    private static TieviivaFeature parseTieviiva(XMLStreamReader reader) throws XMLStreamException {
+        long gid = Long.parseLong(reader.getAttributeValue(null, "gid"));
+        LocalDate alkupvm = null;
+        @Nullable LocalDate loppupvm = null;
+        int kohdeluokka = 0;
+        boolean kohdeluokkaSet = false;
+        int paallyste = 0;
+        boolean paallystemSet = false;
+        @Nullable Integer hallinnollinenLuokka = null;
+        int yksisuuntaisuus = 0;
+        boolean yksisuuntaisuusSet = false;
+        @Nullable String nameFi = null;
+        @Nullable String nameSv = null;
+        @Nullable String nameSmn = null;
+        @Nullable String nameSms = null;
+        @Nullable String nameSme = null;
+        @Nullable Integer minAddressLeft = null;
+        @Nullable Integer maxAddressLeft = null;
+        @Nullable Integer minAddressRight = null;
+        @Nullable Integer maxAddressRight = null;
+        @Nullable String kuntatunnus = null;
+        double[][] lineCoordinates = null;
+
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                switch (reader.getLocalName()) {
+                    case "alkupvm" -> alkupvm = LocalDate.parse(readElementText(reader));
+                    case "loppupvm" -> loppupvm = LocalDate.parse(readElementText(reader));
+                    case "kohdeluokka" -> { kohdeluokka = Integer.parseInt(readElementText(reader)); kohdeluokkaSet = true; }
+                    case "paallyste" -> { paallyste = Integer.parseInt(readElementText(reader)); paallystemSet = true; }
+                    case "hallinnollinenLuokka" -> hallinnollinenLuokka = Integer.parseInt(readElementText(reader));
+                    case "yksisuuntaisuus" -> { yksisuuntaisuus = Integer.parseInt(readElementText(reader)); yksisuuntaisuusSet = true; }
+                    case "nimi_suomi" -> nameFi = readElementText(reader);
+                    case "nimi_ruotsi" -> nameSv = readElementText(reader);
+                    case "nimi_inarinsaame" -> nameSmn = readElementText(reader);
+                    case "nimi_koltansaame" -> nameSms = readElementText(reader);
+                    case "nimi_pohjoissaame" -> nameSme = readElementText(reader);
+                    case "minOsoitenumeroVasen" -> minAddressLeft = zeroToNull(Integer.parseInt(readElementText(reader)));
+                    case "maxOsoitenumeroVasen" -> maxAddressLeft = zeroToNull(Integer.parseInt(readElementText(reader)));
+                    case "minOsoitenumeroOikea" -> minAddressRight = zeroToNull(Integer.parseInt(readElementText(reader)));
+                    case "maxOsoitenumeroOikea" -> maxAddressRight = zeroToNull(Integer.parseInt(readElementText(reader)));
+                    case "kuntatunnus" -> kuntatunnus = readElementText(reader);
+                    case "Murtoviiva" -> lineCoordinates = parsePosList(reader);
+                    default -> { /* skip */ }
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "Tieviiva".equals(reader.getLocalName())) {
+                break;
+            }
+        }
+
+        if (alkupvm == null) throw new IllegalStateException("Missing alkupvm");
+        if (!kohdeluokkaSet) throw new IllegalStateException("Missing kohdeluokka");
+        if (!paallystemSet) throw new IllegalStateException("Missing paallyste");
+        if (!yksisuuntaisuusSet) throw new IllegalStateException("Missing yksisuuntaisuus");
+        if (lineCoordinates == null) throw new IllegalStateException("Missing line coordinates");
+
+        return new TieviivaFeature(gid, alkupvm, loppupvm, kohdeluokka, paallyste, hallinnollinenLuokka,
+                yksisuuntaisuus, nameFi, nameSv, nameSmn, nameSms, nameSme,
+                minAddressLeft, maxAddressLeft, minAddressRight, maxAddressRight, kuntatunnus, lineCoordinates);
+    }
+
+    private static OsoitepisteFeature parseOsoitepiste(XMLStreamReader reader) throws XMLStreamException {
+        long gid = Long.parseLong(reader.getAttributeValue(null, "gid"));
+        LocalDate alkupvm = null;
+        @Nullable LocalDate loppupvm = null;
+        @Nullable String numero = null;
+        @Nullable String nameFi = null;
+        @Nullable String nameSv = null;
+        @Nullable String nameSmn = null;
+        @Nullable String nameSms = null;
+        @Nullable String nameSme = null;
+        @Nullable String kuntatunnus = null;
+        double[] point = null;
+
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                switch (reader.getLocalName()) {
+                    case "alkupvm" -> alkupvm = LocalDate.parse(readElementText(reader));
+                    case "loppupvm" -> loppupvm = LocalDate.parse(readElementText(reader));
+                    case "numero" -> numero = readElementText(reader);
+                    case "nimi_suomi" -> nameFi = readElementText(reader);
+                    case "nimi_ruotsi" -> nameSv = readElementText(reader);
+                    case "nimi_inarinsaame" -> nameSmn = readElementText(reader);
+                    case "nimi_koltansaame" -> nameSms = readElementText(reader);
+                    case "nimi_pohjoissaame" -> nameSme = readElementText(reader);
+                    case "kuntatunnus" -> kuntatunnus = readElementText(reader);
+                    case "Piste" -> point = parsePoint(reader);
+                    default -> { /* skip */ }
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "Osoitepiste".equals(reader.getLocalName())) {
+                break;
+            }
+        }
+
+        if (alkupvm == null) throw new IllegalStateException("Missing alkupvm");
+        if (point == null) throw new IllegalStateException("Missing point coordinates");
+
+        return new OsoitepisteFeature(gid, alkupvm, loppupvm, numero, nameFi, nameSv, nameSmn, nameSms, nameSme,
+                kuntatunnus, point[0], point[1]);
+    }
+
+    private static PaikannimiFeature parsePaikannimi(XMLStreamReader reader) throws XMLStreamException {
+        long gid = Long.parseLong(reader.getAttributeValue(null, "gid"));
+        LocalDate alkupvm = null;
+        @Nullable LocalDate loppupvm = null;
+        String teksti = null;
+        String kieli = null;
+        int kohdeluokka = 0;
+        boolean kohdeluokkaSet = false;
+        @Nullable Long karttanimiId = null;
+        double[] point = null;
+
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                switch (reader.getLocalName()) {
+                    case "alkupvm" -> alkupvm = LocalDate.parse(readElementText(reader));
+                    case "loppupvm" -> loppupvm = LocalDate.parse(readElementText(reader));
+                    case "teksti" -> {
+                        kieli = reader.getAttributeValue(null, "kieli");
+                        teksti = readElementText(reader);
+                    }
+                    case "kohdeluokka" -> { kohdeluokka = Integer.parseInt(readElementText(reader)); kohdeluokkaSet = true; }
+                    case "nrKarttanimiId" -> karttanimiId = Long.parseLong(readElementText(reader));
+                    case "Piste" -> point = parsePoint(reader);
+                    default -> { /* skip */ }
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "Paikannimi".equals(reader.getLocalName())) {
+                break;
+            }
+        }
+
+        if (alkupvm == null) throw new IllegalStateException("Missing alkupvm");
+        if (teksti == null) throw new IllegalStateException("Missing teksti");
+        if (kieli == null) throw new IllegalStateException("Missing kieli attribute on teksti");
+        if (!kohdeluokkaSet) throw new IllegalStateException("Missing kohdeluokka");
+        if (point == null) throw new IllegalStateException("Missing point coordinates");
+
+        return new PaikannimiFeature(gid, alkupvm, loppupvm, teksti, kieli, kohdeluokka, karttanimiId,
+                point[0], point[1]);
+    }
+
+    /**
+     * Parses a {@code <Piste><gml:pos>} element and returns {@code [easting, northing]}.
+     * Elevation (if present) is dropped.
+     */
+    private static double[] parsePoint(XMLStreamReader reader) throws XMLStreamException {
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT && "pos".equals(reader.getLocalName())) {
+                var text = readElementText(reader);
+                var parts = text.trim().split("\\s+");
+                return new double[]{Double.parseDouble(parts[0]), Double.parseDouble(parts[1])};
+            } else if (event == XMLStreamConstants.END_ELEMENT && "Piste".equals(reader.getLocalName())) {
+                break;
+            }
+        }
+        throw new IllegalStateException("No gml:pos found inside Piste");
+    }
+
+    /**
+     * Parses a {@code <gml:posList>} element within the current element and returns coordinate pairs.
+     * Uses the {@code srsDimension} attribute to determine stride (2 or 3). Elevation is dropped.
+     */
+    private static double[][] parsePosList(XMLStreamReader reader) throws XMLStreamException {
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT && "posList".equals(reader.getLocalName())) {
+                int srsDimension = 2;
+                var dimAttr = reader.getAttributeValue(null, "srsDimension");
+                if (dimAttr != null) {
+                    srsDimension = Integer.parseInt(dimAttr);
+                }
+                var text = readElementText(reader);
+                var parts = text.trim().split("\\s+");
+                int numCoords = parts.length / srsDimension;
+                var coordinates = new double[numCoords][2];
+                for (int i = 0; i < numCoords; i++) {
+                    int offset = i * srsDimension;
+                    coordinates[i][0] = Double.parseDouble(parts[offset]);
+                    coordinates[i][1] = Double.parseDouble(parts[offset + 1]);
+                }
+                return coordinates;
+            }
+        }
+        throw new IllegalStateException("No gml:posList found");
+    }
+
+    /**
+     * Reads the text content of the current element and returns it.
+     * Consumes events until the element's END_ELEMENT is reached.
+     */
+    private static String readElementText(XMLStreamReader reader) throws XMLStreamException {
+        return reader.getElementText();
+    }
+
+    /**
+     * Returns {@code null} if the value is 0, otherwise returns the value.
+     * Used for address range fields where 0 means "no addresses on this side".
+     */
+    private static @Nullable Integer zeroToNull(int value) {
+        return value == 0 ? null : value;
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParser.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParser.java
@@ -337,6 +337,10 @@ public final class NlsGmlParser {
                 }
                 var text = readElementText(reader);
                 var parts = text.trim().split("\\s+");
+                if (parts.length % srsDimension != 0) {
+                    throw new IllegalStateException(
+                            "posList value count " + parts.length + " is not divisible by srsDimension " + srsDimension);
+                }
                 int numCoords = parts.length / srsDimension;
                 var coordinates = new double[numCoords][2];
                 for (int i = 0; i < numCoords; i++) {

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParser.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParser.java
@@ -82,6 +82,8 @@ public final class NlsGmlParser {
         KuntaFeature feature;
         try {
             feature = parseKunta(reader);
+        } catch (XMLStreamException e) {
+            throw e;
         } catch (Exception e) {
             log.warn("Failed to parse Kunta feature, skipping: {}", e.getMessage());
             return;
@@ -93,6 +95,8 @@ public final class NlsGmlParser {
         TieviivaFeature feature;
         try {
             feature = parseTieviiva(reader);
+        } catch (XMLStreamException e) {
+            throw e;
         } catch (Exception e) {
             log.warn("Failed to parse Tieviiva feature, skipping: {}", e.getMessage());
             return;
@@ -104,6 +108,8 @@ public final class NlsGmlParser {
         OsoitepisteFeature feature;
         try {
             feature = parseOsoitepiste(reader);
+        } catch (XMLStreamException e) {
+            throw e;
         } catch (Exception e) {
             log.warn("Failed to parse Osoitepiste feature, skipping: {}", e.getMessage());
             return;
@@ -115,6 +121,8 @@ public final class NlsGmlParser {
         PaikannimiFeature feature;
         try {
             feature = parsePaikannimi(reader);
+        } catch (XMLStreamException e) {
+            throw e;
         } catch (Exception e) {
             log.warn("Failed to parse Paikannimi feature, skipping: {}", e.getMessage());
             return;

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/KuntaFeature.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/KuntaFeature.java
@@ -1,0 +1,23 @@
+package net.pkhapps.idispatchx.gis.importer.parser.model;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+
+/**
+ * Parsed Kunta (municipality boundary) feature from NLS GML data.
+ *
+ * @param gid                 globally unique NLS feature identifier
+ * @param alkupvm             feature creation/modification date
+ * @param loppupvm            feature end/retirement date, or {@code null} if active
+ * @param kuntatunnus         3-digit municipality code
+ * @param polygonCoordinates  boundary polygon coordinates as easting/northing pairs in EPSG:3067
+ */
+public record KuntaFeature(
+        long gid,
+        LocalDate alkupvm,
+        @Nullable LocalDate loppupvm,
+        String kuntatunnus,
+        double[][] polygonCoordinates
+) {
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/OsoitepisteFeature.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/OsoitepisteFeature.java
@@ -1,0 +1,37 @@
+package net.pkhapps.idispatchx.gis.importer.parser.model;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+
+/**
+ * Parsed Osoitepiste (address point) feature from NLS GML data.
+ *
+ * @param gid           globally unique NLS feature identifier
+ * @param alkupvm       feature creation/modification date
+ * @param loppupvm      feature end/retirement date, or {@code null} if active
+ * @param numero        address number (may contain letters, e.g. "427s"), or {@code null}
+ * @param nameFi        Finnish street name, or {@code null}
+ * @param nameSv        Swedish street name, or {@code null}
+ * @param nameSmn       Inari Sami name, or {@code null}
+ * @param nameSms       Skolt Sami name, or {@code null}
+ * @param nameSme       Northern Sami name, or {@code null}
+ * @param kuntatunnus   municipality code, or {@code null}
+ * @param pointEasting  point easting coordinate in EPSG:3067
+ * @param pointNorthing point northing coordinate in EPSG:3067
+ */
+public record OsoitepisteFeature(
+        long gid,
+        LocalDate alkupvm,
+        @Nullable LocalDate loppupvm,
+        @Nullable String numero,
+        @Nullable String nameFi,
+        @Nullable String nameSv,
+        @Nullable String nameSmn,
+        @Nullable String nameSms,
+        @Nullable String nameSme,
+        @Nullable String kuntatunnus,
+        double pointEasting,
+        double pointNorthing
+) {
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/PaikannimiFeature.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/PaikannimiFeature.java
@@ -1,0 +1,31 @@
+package net.pkhapps.idispatchx.gis.importer.parser.model;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+
+/**
+ * Parsed Paikannimi (place name) feature from NLS GML data.
+ *
+ * @param gid           globally unique NLS feature identifier
+ * @param alkupvm       feature creation/modification date
+ * @param loppupvm      feature end/retirement date, or {@code null} if active
+ * @param teksti        the place name text
+ * @param kieli         language code (ISO 639: "fin", "swe", "smn", "sms", "sme")
+ * @param kohdeluokka   place name class code
+ * @param karttanimiId  map name register ID linking multilingual entries, or {@code null}
+ * @param pointEasting  point easting coordinate in EPSG:3067
+ * @param pointNorthing point northing coordinate in EPSG:3067
+ */
+public record PaikannimiFeature(
+        long gid,
+        LocalDate alkupvm,
+        @Nullable LocalDate loppupvm,
+        String teksti,
+        String kieli,
+        int kohdeluokka,
+        @Nullable Long karttanimiId,
+        double pointEasting,
+        double pointNorthing
+) {
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/TieviivaFeature.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/TieviivaFeature.java
@@ -1,0 +1,49 @@
+package net.pkhapps.idispatchx.gis.importer.parser.model;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+
+/**
+ * Parsed Tieviiva (road segment) feature from NLS GML data.
+ *
+ * @param gid                 globally unique NLS feature identifier
+ * @param alkupvm             feature creation/modification date
+ * @param loppupvm            feature end/retirement date, or {@code null} if active
+ * @param kohdeluokka         road class code
+ * @param paallyste           surface type (0=unknown, 1=unpaved, 2=paved)
+ * @param hallinnollinenLuokka administrative class, or {@code null} if not specified
+ * @param yksisuuntaisuus     one-way direction (0=bidirectional, 1=forward, 2=backward)
+ * @param nameFi              Finnish street name, or {@code null}
+ * @param nameSv              Swedish street name, or {@code null}
+ * @param nameSmn             Inari Sami name, or {@code null}
+ * @param nameSms             Skolt Sami name, or {@code null}
+ * @param nameSme             Northern Sami name, or {@code null}
+ * @param minAddressLeft      min address number on left side, or {@code null} if none
+ * @param maxAddressLeft      max address number on left side, or {@code null} if none
+ * @param minAddressRight     min address number on right side, or {@code null} if none
+ * @param maxAddressRight     max address number on right side, or {@code null} if none
+ * @param kuntatunnus         municipality code, or {@code null}
+ * @param lineCoordinates     road centerline coordinates as easting/northing pairs in EPSG:3067
+ */
+public record TieviivaFeature(
+        long gid,
+        LocalDate alkupvm,
+        @Nullable LocalDate loppupvm,
+        int kohdeluokka,
+        int paallyste,
+        @Nullable Integer hallinnollinenLuokka,
+        int yksisuuntaisuus,
+        @Nullable String nameFi,
+        @Nullable String nameSv,
+        @Nullable String nameSmn,
+        @Nullable String nameSms,
+        @Nullable String nameSme,
+        @Nullable Integer minAddressLeft,
+        @Nullable Integer maxAddressLeft,
+        @Nullable Integer minAddressRight,
+        @Nullable Integer maxAddressRight,
+        @Nullable String kuntatunnus,
+        double[][] lineCoordinates
+) {
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/package-info.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package net.pkhapps.idispatchx.gis.importer.parser.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/package-info.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package net.pkhapps.idispatchx.gis.importer.parser;
+
+import org.jspecify.annotations.NullMarked;

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/FeatureTypeTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/FeatureTypeTest.java
@@ -1,0 +1,21 @@
+package net.pkhapps.idispatchx.gis.importer.parser;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FeatureTypeTest {
+
+    @Test
+    void elementNames_matchGmlElementNames() {
+        assertEquals("Kunta", FeatureType.KUNTA.elementName());
+        assertEquals("Tieviiva", FeatureType.TIEVIIVA.elementName());
+        assertEquals("Osoitepiste", FeatureType.OSOITEPISTE.elementName());
+        assertEquals("Paikannimi", FeatureType.PAIKANNIMI.elementName());
+    }
+
+    @Test
+    void values_containsAllFourTypes() {
+        assertEquals(4, FeatureType.values().length);
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
@@ -534,6 +534,46 @@ class NlsGmlParserTest {
         assertEquals("DB write failed", ex.getMessage());
     }
 
+    @Test
+    void parse_malformedPosList_skipsFeature() throws XMLStreamException {
+        var xml = """
+                <kunnat>
+                    <Kunta gid="1" dimension="3">
+                        <alkupvm>2009-01-01</alkupvm>
+                        <sijainti>
+                            <Alue>
+                                <gml:exterior>
+                                    <gml:LinearRing>
+                                        <gml:posList srsDimension="3">100.0 200.0 5.0 300.0 400.0</gml:posList>
+                                    </gml:LinearRing>
+                                </gml:exterior>
+                            </Alue>
+                        </sijainti>
+                        <kuntatunnus>001</kuntatunnus>
+                    </Kunta>
+                    <Kunta gid="2" dimension="2">
+                        <alkupvm>2009-01-01</alkupvm>
+                        <sijainti>
+                            <Alue>
+                                <gml:exterior>
+                                    <gml:LinearRing>
+                                        <gml:posList srsDimension="2">100.0 200.0 300.0 400.0 100.0 200.0</gml:posList>
+                                    </gml:LinearRing>
+                                </gml:exterior>
+                            </Alue>
+                        </sijainti>
+                        <kuntatunnus>002</kuntatunnus>
+                    </Kunta>
+                </kunnat>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        // First Kunta has 5 values for srsDimension=3 (not divisible), should be skipped
+        assertEquals(1, visitor.kunnat.size());
+        assertEquals("002", visitor.kunnat.getFirst().kuntatunnus());
+    }
+
     // === Empty document ===
 
     @Test

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
@@ -1,0 +1,606 @@
+package net.pkhapps.idispatchx.gis.importer.parser;
+
+import net.pkhapps.idispatchx.gis.importer.parser.model.KuntaFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.OsoitepisteFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.PaikannimiFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.TieviivaFeature;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NlsGmlParserTest {
+
+    // === Helper classes ===
+
+    private static class CollectingVisitor implements FeatureVisitor {
+        final List<KuntaFeature> kunnat = new ArrayList<>();
+        final List<TieviivaFeature> tieviivat = new ArrayList<>();
+        final List<OsoitepisteFeature> osoitepisteet = new ArrayList<>();
+        final List<PaikannimiFeature> paikannimet = new ArrayList<>();
+
+        @Override
+        public void onKunta(KuntaFeature feature) {
+            kunnat.add(feature);
+        }
+
+        @Override
+        public void onTieviiva(TieviivaFeature feature) {
+            tieviivat.add(feature);
+        }
+
+        @Override
+        public void onOsoitepiste(OsoitepisteFeature feature) {
+            osoitepisteet.add(feature);
+        }
+
+        @Override
+        public void onPaikannimi(PaikannimiFeature feature) {
+            paikannimet.add(feature);
+        }
+    }
+
+    private static InputStream gmlStream(String featureXml) {
+        var doc = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Maastotiedot xmlns="http://xml.nls.fi/XML/Namespace/Maastotietojarjestelma/SiirtotiedostonMalli/2011-02"
+                              xmlns:gml="http://www.opengis.net/gml"
+                              srsName="EPSG:3067, EPSG:5717">
+                """ + featureXml + """
+                </Maastotiedot>
+                """;
+        return new ByteArrayInputStream(doc.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // === Kunta parsing ===
+
+    @Test
+    void parseKunta_fullFields_parsesCorrectly() throws XMLStreamException {
+        var xml = """
+                <kunnat>
+                    <Kunta gid="27696440" dimension="3">
+                        <sijaintitarkkuus>0</sijaintitarkkuus>
+                        <aineistolahde>1</aineistolahde>
+                        <alkupvm>2009-01-01</alkupvm>
+                        <sijainti>
+                            <Piste><gml:pos srsDimension="3">230000.000 6672000.001 0.000</gml:pos></Piste>
+                            <Alue>
+                                <gml:exterior>
+                                    <gml:LinearRing>
+                                        <gml:posList srsDimension="3">234265.396 6669060.097 0.000 231796.382 6666000.000 0.000 232000.000 6666000.000 0.000 234265.396 6669060.097 0.000</gml:posList>
+                                    </gml:LinearRing>
+                                </gml:exterior>
+                            </Alue>
+                        </sijainti>
+                        <kohderyhma>71</kohderyhma>
+                        <kohdeluokka>84200</kohdeluokka>
+                        <kuntatunnus>445</kuntatunnus>
+                    </Kunta>
+                </kunnat>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        assertEquals(1, visitor.kunnat.size());
+        var kunta = visitor.kunnat.getFirst();
+        assertEquals(27696440L, kunta.gid());
+        assertEquals(LocalDate.of(2009, 1, 1), kunta.alkupvm());
+        assertNull(kunta.loppupvm());
+        assertEquals("445", kunta.kuntatunnus());
+        assertEquals(4, kunta.polygonCoordinates().length);
+        assertEquals(234265.396, kunta.polygonCoordinates()[0][0], 1e-3);
+        assertEquals(6669060.097, kunta.polygonCoordinates()[0][1], 1e-3);
+    }
+
+    @Test
+    void parseKunta_withLoppupvm_parsesEndDate() throws XMLStreamException {
+        var xml = """
+                <kunnat>
+                    <Kunta gid="12345" dimension="2">
+                        <alkupvm>2009-01-01</alkupvm>
+                        <loppupvm>2020-06-15</loppupvm>
+                        <sijainti>
+                            <Alue>
+                                <gml:exterior>
+                                    <gml:LinearRing>
+                                        <gml:posList srsDimension="2">100.0 200.0 300.0 400.0 100.0 200.0</gml:posList>
+                                    </gml:LinearRing>
+                                </gml:exterior>
+                            </Alue>
+                        </sijainti>
+                        <kuntatunnus>100</kuntatunnus>
+                    </Kunta>
+                </kunnat>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        assertEquals(1, visitor.kunnat.size());
+        assertEquals(LocalDate.of(2020, 6, 15), visitor.kunnat.getFirst().loppupvm());
+    }
+
+    @Test
+    void parseKunta_2dCoordinates_parsesCorrectly() throws XMLStreamException {
+        var xml = """
+                <kunnat>
+                    <Kunta gid="1" dimension="2">
+                        <alkupvm>2009-01-01</alkupvm>
+                        <sijainti>
+                            <Alue>
+                                <gml:exterior>
+                                    <gml:LinearRing>
+                                        <gml:posList srsDimension="2">100.0 200.0 300.0 400.0 100.0 200.0</gml:posList>
+                                    </gml:LinearRing>
+                                </gml:exterior>
+                            </Alue>
+                        </sijainti>
+                        <kuntatunnus>001</kuntatunnus>
+                    </Kunta>
+                </kunnat>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        assertEquals(1, visitor.kunnat.size());
+        var coords = visitor.kunnat.getFirst().polygonCoordinates();
+        assertEquals(3, coords.length);
+        assertEquals(100.0, coords[0][0]);
+        assertEquals(200.0, coords[0][1]);
+    }
+
+    @Test
+    void parseKunta_3dCoordinates_dropsElevation() throws XMLStreamException {
+        var xml = """
+                <kunnat>
+                    <Kunta gid="1" dimension="3">
+                        <alkupvm>2009-01-01</alkupvm>
+                        <sijainti>
+                            <Alue>
+                                <gml:exterior>
+                                    <gml:LinearRing>
+                                        <gml:posList srsDimension="3">100.0 200.0 5.0 300.0 400.0 10.0 100.0 200.0 5.0</gml:posList>
+                                    </gml:LinearRing>
+                                </gml:exterior>
+                            </Alue>
+                        </sijainti>
+                        <kuntatunnus>001</kuntatunnus>
+                    </Kunta>
+                </kunnat>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        var coords = visitor.kunnat.getFirst().polygonCoordinates();
+        assertEquals(3, coords.length);
+        assertEquals(100.0, coords[0][0]);
+        assertEquals(200.0, coords[0][1]);
+        assertEquals(2, coords[0].length); // only easting and northing, no elevation
+    }
+
+    // === Tieviiva parsing ===
+
+    @Test
+    void parseTieviiva_fullFields_parsesCorrectly() throws XMLStreamException {
+        var xml = """
+                <tieviivat>
+                    <Tieviiva gid="1186733682" dimension="3">
+                        <sijaintitarkkuus>3000</sijaintitarkkuus>
+                        <korkeustarkkuus>201</korkeustarkkuus>
+                        <aineistolahde>1</aineistolahde>
+                        <alkupvm>2018-06-05</alkupvm>
+                        <kulkutapa>2</kulkutapa>
+                        <sijainti>
+                            <Murtoviiva>
+                                <gml:posList srsDimension="3">232056.555 6678000.000 7.480 232100.000 6678050.000 8.000</gml:posList>
+                            </Murtoviiva>
+                        </sijainti>
+                        <kohderyhma>25</kohderyhma>
+                        <kohdeluokka>12141</kohdeluokka>
+                        <tasosijainti>0</tasosijainti>
+                        <valmiusaste>0</valmiusaste>
+                        <paallyste>1</paallyste>
+                        <yksisuuntaisuus>0</yksisuuntaisuus>
+                        <hallinnollinenLuokka>3</hallinnollinenLuokka>
+                        <nimi_suomi kieli="fin">Kuggöntie</nimi_suomi>
+                        <nimi_ruotsi kieli="swe">Kuggövägen</nimi_ruotsi>
+                        <minOsoitenumeroVasen>1</minOsoitenumeroVasen>
+                        <maxOsoitenumeroVasen>99</maxOsoitenumeroVasen>
+                        <minOsoitenumeroOikea>2</minOsoitenumeroOikea>
+                        <maxOsoitenumeroOikea>100</maxOsoitenumeroOikea>
+                        <kuntatunnus>445</kuntatunnus>
+                    </Tieviiva>
+                </tieviivat>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        assertEquals(1, visitor.tieviivat.size());
+        var tv = visitor.tieviivat.getFirst();
+        assertEquals(1186733682L, tv.gid());
+        assertEquals(LocalDate.of(2018, 6, 5), tv.alkupvm());
+        assertNull(tv.loppupvm());
+        assertEquals(12141, tv.kohdeluokka());
+        assertEquals(1, tv.paallyste());
+        assertEquals(3, tv.hallinnollinenLuokka());
+        assertEquals(0, tv.yksisuuntaisuus());
+        assertEquals("Kuggöntie", tv.nameFi());
+        assertEquals("Kuggövägen", tv.nameSv());
+        assertNull(tv.nameSmn());
+        assertNull(tv.nameSms());
+        assertNull(tv.nameSme());
+        assertEquals(1, tv.minAddressLeft());
+        assertEquals(99, tv.maxAddressLeft());
+        assertEquals(2, tv.minAddressRight());
+        assertEquals(100, tv.maxAddressRight());
+        assertEquals("445", tv.kuntatunnus());
+        assertEquals(2, tv.lineCoordinates().length);
+        assertEquals(232056.555, tv.lineCoordinates()[0][0], 1e-3);
+    }
+
+    @Test
+    void parseTieviiva_zeroAddressRanges_becomesNull() throws XMLStreamException {
+        var xml = """
+                <tieviivat>
+                    <Tieviiva gid="1" dimension="3">
+                        <alkupvm>2018-06-05</alkupvm>
+                        <sijainti>
+                            <Murtoviiva>
+                                <gml:posList srsDimension="3">100.0 200.0 0.0 300.0 400.0 0.0</gml:posList>
+                            </Murtoviiva>
+                        </sijainti>
+                        <kohdeluokka>12141</kohdeluokka>
+                        <paallyste>1</paallyste>
+                        <yksisuuntaisuus>0</yksisuuntaisuus>
+                        <minOsoitenumeroVasen>0</minOsoitenumeroVasen>
+                        <maxOsoitenumeroVasen>0</maxOsoitenumeroVasen>
+                        <minOsoitenumeroOikea>0</minOsoitenumeroOikea>
+                        <maxOsoitenumeroOikea>0</maxOsoitenumeroOikea>
+                    </Tieviiva>
+                </tieviivat>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        var tv = visitor.tieviivat.getFirst();
+        assertNull(tv.minAddressLeft());
+        assertNull(tv.maxAddressLeft());
+        assertNull(tv.minAddressRight());
+        assertNull(tv.maxAddressRight());
+    }
+
+    @Test
+    void parseTieviiva_minimalFields_parsesWithNulls() throws XMLStreamException {
+        var xml = """
+                <tieviivat>
+                    <Tieviiva gid="1" dimension="2">
+                        <alkupvm>2018-06-05</alkupvm>
+                        <sijainti>
+                            <Murtoviiva>
+                                <gml:posList srsDimension="2">100.0 200.0 300.0 400.0</gml:posList>
+                            </Murtoviiva>
+                        </sijainti>
+                        <kohdeluokka>12313</kohdeluokka>
+                        <paallyste>0</paallyste>
+                        <yksisuuntaisuus>0</yksisuuntaisuus>
+                    </Tieviiva>
+                </tieviivat>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        var tv = visitor.tieviivat.getFirst();
+        assertNull(tv.hallinnollinenLuokka());
+        assertNull(tv.nameFi());
+        assertNull(tv.nameSv());
+        assertNull(tv.kuntatunnus());
+        assertNull(tv.minAddressLeft());
+    }
+
+    // === Osoitepiste parsing ===
+
+    @Test
+    void parseOsoitepiste_fullFields_parsesCorrectly() throws XMLStreamException {
+        var xml = """
+                <osoitepisteet>
+                    <Osoitepiste gid="1754319417" dimension="2">
+                        <sijaintitarkkuus>12500</sijaintitarkkuus>
+                        <korkeustarkkuus>1</korkeustarkkuus>
+                        <aineistolahde>1</aineistolahde>
+                        <alkupvm>2016-10-11</alkupvm>
+                        <suunta>0</suunta>
+                        <sijainti>
+                            <Piste><gml:pos srsDimension="2">231221.828 6677931.943</gml:pos></Piste>
+                        </sijainti>
+                        <kohderyhma>2</kohderyhma>
+                        <kohdeluokka>96001</kohdeluokka>
+                        <numero>427s</numero>
+                        <nimi_suomi kieli="fin">Kuggö</nimi_suomi>
+                        <nimi_ruotsi kieli="swe">Kuggö</nimi_ruotsi>
+                        <kuntatunnus>445</kuntatunnus>
+                    </Osoitepiste>
+                </osoitepisteet>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        assertEquals(1, visitor.osoitepisteet.size());
+        var op = visitor.osoitepisteet.getFirst();
+        assertEquals(1754319417L, op.gid());
+        assertEquals(LocalDate.of(2016, 10, 11), op.alkupvm());
+        assertNull(op.loppupvm());
+        assertEquals("427s", op.numero());
+        assertEquals("Kuggö", op.nameFi());
+        assertEquals("Kuggö", op.nameSv());
+        assertNull(op.nameSmn());
+        assertEquals("445", op.kuntatunnus());
+        assertEquals(231221.828, op.pointEasting(), 1e-3);
+        assertEquals(6677931.943, op.pointNorthing(), 1e-3);
+    }
+
+    @Test
+    void parseOsoitepiste_3dCoordinates_dropsElevation() throws XMLStreamException {
+        var xml = """
+                <osoitepisteet>
+                    <Osoitepiste gid="1" dimension="3">
+                        <alkupvm>2016-10-11</alkupvm>
+                        <sijainti>
+                            <Piste><gml:pos srsDimension="3">100.0 200.0 50.0</gml:pos></Piste>
+                        </sijainti>
+                    </Osoitepiste>
+                </osoitepisteet>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        var op = visitor.osoitepisteet.getFirst();
+        assertEquals(100.0, op.pointEasting());
+        assertEquals(200.0, op.pointNorthing());
+    }
+
+    @Test
+    void parseOsoitepiste_minimalFields_parsesWithNulls() throws XMLStreamException {
+        var xml = """
+                <osoitepisteet>
+                    <Osoitepiste gid="1" dimension="2">
+                        <alkupvm>2016-10-11</alkupvm>
+                        <sijainti>
+                            <Piste><gml:pos srsDimension="2">100.0 200.0</gml:pos></Piste>
+                        </sijainti>
+                    </Osoitepiste>
+                </osoitepisteet>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        var op = visitor.osoitepisteet.getFirst();
+        assertNull(op.numero());
+        assertNull(op.nameFi());
+        assertNull(op.nameSv());
+        assertNull(op.kuntatunnus());
+    }
+
+    // === Paikannimi parsing ===
+
+    @Test
+    void parsePaikannimi_fullFields_parsesCorrectly() throws XMLStreamException {
+        var xml = """
+                <paikannimet>
+                    <Paikannimi gid="70304994" dimension="2">
+                        <sijaintitarkkuus>0</sijaintitarkkuus>
+                        <aineistolahde>1</aineistolahde>
+                        <alkupvm>2016-05-04</alkupvm>
+                        <teksti kieli="swe">Lilla Gulskär</teksti>
+                        <suunta>0</suunta>
+                        <dx>-33801</dx>
+                        <dy>-95370</dy>
+                        <sijainti>
+                            <Piste><gml:pos srsDimension="2">228723.269 6674958.712</gml:pos></Piste>
+                        </sijainti>
+                        <kohderyhma>16</kohderyhma>
+                        <kohdeluokka>35070</kohdeluokka>
+                        <ladontatunnus>6111</ladontatunnus>
+                        <versaalitieto>0</versaalitieto>
+                        <nrKarttanimiId>70304994</nrKarttanimiId>
+                    </Paikannimi>
+                </paikannimet>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        assertEquals(1, visitor.paikannimet.size());
+        var pn = visitor.paikannimet.getFirst();
+        assertEquals(70304994L, pn.gid());
+        assertEquals(LocalDate.of(2016, 5, 4), pn.alkupvm());
+        assertNull(pn.loppupvm());
+        assertEquals("Lilla Gulskär", pn.teksti());
+        assertEquals("swe", pn.kieli());
+        assertEquals(35070, pn.kohdeluokka());
+        assertEquals(70304994L, pn.karttanimiId());
+        assertEquals(228723.269, pn.pointEasting(), 1e-3);
+        assertEquals(6674958.712, pn.pointNorthing(), 1e-3);
+    }
+
+    @Test
+    void parsePaikannimi_withoutKarttanimiId_parsesAsNull() throws XMLStreamException {
+        var xml = """
+                <paikannimet>
+                    <Paikannimi gid="1" dimension="2">
+                        <alkupvm>2016-05-04</alkupvm>
+                        <teksti kieli="fin">Testipaikka</teksti>
+                        <sijainti>
+                            <Piste><gml:pos srsDimension="2">100.0 200.0</gml:pos></Piste>
+                        </sijainti>
+                        <kohdeluokka>35010</kohdeluokka>
+                    </Paikannimi>
+                </paikannimet>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        var pn = visitor.paikannimet.getFirst();
+        assertEquals("Testipaikka", pn.teksti());
+        assertEquals("fin", pn.kieli());
+        assertNull(pn.karttanimiId());
+    }
+
+    // === Feature type filtering ===
+
+    @Test
+    void parse_filterByType_onlyParsesRequestedTypes() throws XMLStreamException {
+        var xml = """
+                <kunnat>
+                    <Kunta gid="1" dimension="2">
+                        <alkupvm>2009-01-01</alkupvm>
+                        <sijainti>
+                            <Alue><gml:exterior><gml:LinearRing>
+                                <gml:posList srsDimension="2">100.0 200.0 300.0 400.0 100.0 200.0</gml:posList>
+                            </gml:LinearRing></gml:exterior></Alue>
+                        </sijainti>
+                        <kuntatunnus>001</kuntatunnus>
+                    </Kunta>
+                </kunnat>
+                <paikannimet>
+                    <Paikannimi gid="2" dimension="2">
+                        <alkupvm>2016-05-04</alkupvm>
+                        <teksti kieli="fin">Test</teksti>
+                        <sijainti><Piste><gml:pos srsDimension="2">100.0 200.0</gml:pos></Piste></sijainti>
+                        <kohdeluokka>35010</kohdeluokka>
+                    </Paikannimi>
+                </paikannimet>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor, EnumSet.of(FeatureType.PAIKANNIMI));
+
+        assertEquals(0, visitor.kunnat.size());
+        assertEquals(1, visitor.paikannimet.size());
+    }
+
+    // === Error handling ===
+
+    @Test
+    void parse_malformedFeature_skipsAndContinues() throws XMLStreamException {
+        var xml = """
+                <paikannimet>
+                    <Paikannimi gid="1" dimension="2">
+                        <alkupvm>2016-05-04</alkupvm>
+                    </Paikannimi>
+                    <Paikannimi gid="2" dimension="2">
+                        <alkupvm>2016-05-04</alkupvm>
+                        <teksti kieli="fin">Valid</teksti>
+                        <sijainti><Piste><gml:pos srsDimension="2">100.0 200.0</gml:pos></Piste></sijainti>
+                        <kohdeluokka>35010</kohdeluokka>
+                    </Paikannimi>
+                </paikannimet>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        // First feature is malformed (missing teksti, kohdeluokka, sijainti), second is valid
+        assertEquals(1, visitor.paikannimet.size());
+        assertEquals("Valid", visitor.paikannimet.getFirst().teksti());
+    }
+
+    // === Empty document ===
+
+    @Test
+    void parse_emptyDocument_producesNoFeatures() throws XMLStreamException {
+        var xml = "";
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        assertEquals(0, visitor.kunnat.size());
+        assertEquals(0, visitor.tieviivat.size());
+        assertEquals(0, visitor.osoitepisteet.size());
+        assertEquals(0, visitor.paikannimet.size());
+    }
+
+    @Test
+    void parse_unrecognizedElements_ignored() throws XMLStreamException {
+        var xml = """
+                <harvatLouhikot>
+                    <HarvaLouhikko gid="1" dimension="2">
+                        <alkupvm>2018-06-05</alkupvm>
+                    </HarvaLouhikko>
+                </harvatLouhikot>
+                """;
+        var visitor = new CollectingVisitor();
+        NlsGmlParser.parse(gmlStream(xml), visitor);
+
+        assertEquals(0, visitor.kunnat.size());
+        assertEquals(0, visitor.tieviivat.size());
+        assertEquals(0, visitor.osoitepisteet.size());
+        assertEquals(0, visitor.paikannimet.size());
+    }
+
+    // === Integration test with sample data ===
+
+    @Test
+    void parse_sampleDataFile_correctFeatureCounts() throws Exception {
+        var sampleFile = Path.of("../../SampleData/L3311R.xml");
+        if (!Files.exists(sampleFile)) {
+            // Skip if sample data not available (e.g., in CI)
+            return;
+        }
+
+        var visitor = new CollectingVisitor();
+        try (var input = new FileInputStream(sampleFile.toFile())) {
+            NlsGmlParser.parse(input, visitor);
+        }
+
+        assertEquals(2, visitor.kunnat.size(), "Expected 2 Kunta features");
+        assertEquals(83, visitor.tieviivat.size(), "Expected 83 Tieviiva features");
+        assertEquals(10, visitor.osoitepisteet.size(), "Expected 10 Osoitepiste features");
+        assertEquals(273, visitor.paikannimet.size(), "Expected 273 Paikannimi features");
+    }
+
+    @Test
+    void parse_sampleDataFile_spotCheckKunta() throws Exception {
+        var sampleFile = Path.of("../../SampleData/L3311R.xml");
+        if (!Files.exists(sampleFile)) {
+            return;
+        }
+
+        var visitor = new CollectingVisitor();
+        try (var input = new FileInputStream(sampleFile.toFile())) {
+            NlsGmlParser.parse(input, visitor);
+        }
+
+        var kunta445 = visitor.kunnat.stream().filter(k -> k.gid() == 27696440L).findFirst().orElseThrow();
+        assertEquals("445", kunta445.kuntatunnus());
+        assertEquals(LocalDate.of(2009, 1, 1), kunta445.alkupvm());
+        assertNull(kunta445.loppupvm());
+        assertTrue(kunta445.polygonCoordinates().length > 2);
+    }
+
+    @Test
+    void parse_sampleDataFile_spotCheckOsoitepiste() throws Exception {
+        var sampleFile = Path.of("../../SampleData/L3311R.xml");
+        if (!Files.exists(sampleFile)) {
+            return;
+        }
+
+        var visitor = new CollectingVisitor();
+        try (var input = new FileInputStream(sampleFile.toFile())) {
+            NlsGmlParser.parse(input, visitor);
+        }
+
+        var op = visitor.osoitepisteet.stream().filter(o -> o.gid() == 1754319417L).findFirst().orElseThrow();
+        assertEquals("427s", op.numero());
+        assertEquals("Kuggö", op.nameFi());
+        assertEquals("Kuggö", op.nameSv());
+        assertEquals("445", op.kuntatunnus());
+        assertEquals(231221.828, op.pointEasting(), 1e-3);
+        assertEquals(6677931.943, op.pointNorthing(), 1e-3);
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
@@ -511,6 +511,29 @@ class NlsGmlParserTest {
         assertEquals("Valid", visitor.paikannimet.getFirst().teksti());
     }
 
+    @Test
+    void parse_visitorException_propagates() {
+        var xml = """
+                <paikannimet>
+                    <Paikannimi gid="1" dimension="2">
+                        <alkupvm>2016-05-04</alkupvm>
+                        <teksti kieli="fin">Test</teksti>
+                        <sijainti><Piste><gml:pos srsDimension="2">100.0 200.0</gml:pos></Piste></sijainti>
+                        <kohdeluokka>35010</kohdeluokka>
+                    </Paikannimi>
+                </paikannimet>
+                """;
+        var failingVisitor = new CollectingVisitor() {
+            @Override
+            public void onPaikannimi(PaikannimiFeature feature) {
+                throw new RuntimeException("DB write failed");
+            }
+        };
+        var ex = assertThrows(RuntimeException.class,
+                () -> NlsGmlParser.parse(gmlStream(xml), failingVisitor));
+        assertEquals("DB write failed", ex.getMessage());
+    }
+
     // === Empty document ===
 
     @Test

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
@@ -570,7 +570,7 @@ class NlsGmlParserTest {
 
     @Test
     void parse_sampleDataFile_correctFeatureCounts() throws Exception {
-        var sampleFile = Path.of("../../SampleData/L3311R.xml");
+        var sampleFile = Path.of("../../../SampleData/L3311R.xml");
         if (!Files.exists(sampleFile)) {
             // Skip if sample data not available (e.g., in CI)
             return;
@@ -589,7 +589,7 @@ class NlsGmlParserTest {
 
     @Test
     void parse_sampleDataFile_spotCheckKunta() throws Exception {
-        var sampleFile = Path.of("../../SampleData/L3311R.xml");
+        var sampleFile = Path.of("../../../SampleData/L3311R.xml");
         if (!Files.exists(sampleFile)) {
             return;
         }
@@ -608,7 +608,7 @@ class NlsGmlParserTest {
 
     @Test
     void parse_sampleDataFile_spotCheckOsoitepiste() throws Exception {
-        var sampleFile = Path.of("../../SampleData/L3311R.xml");
+        var sampleFile = Path.of("../../../SampleData/L3311R.xml");
         if (!Files.exists(sampleFile)) {
             return;
         }

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/NlsGmlParserTest.java
@@ -4,6 +4,7 @@ import net.pkhapps.idispatchx.gis.importer.parser.model.KuntaFeature;
 import net.pkhapps.idispatchx.gis.importer.parser.model.OsoitepisteFeature;
 import net.pkhapps.idispatchx.gis.importer.parser.model.PaikannimiFeature;
 import net.pkhapps.idispatchx.gis.importer.parser.model.TieviivaFeature;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLStreamException;
@@ -21,6 +22,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 class NlsGmlParserTest {
+
+    private static final Path SAMPLE_DATA_FILE = Path.of("../../../SampleData/L3311R.xml");
 
     // === Helper classes ===
 
@@ -610,14 +613,11 @@ class NlsGmlParserTest {
 
     @Test
     void parse_sampleDataFile_correctFeatureCounts() throws Exception {
-        var sampleFile = Path.of("../../../SampleData/L3311R.xml");
-        if (!Files.exists(sampleFile)) {
-            // Skip if sample data not available (e.g., in CI)
-            return;
-        }
+        Assumptions.assumeTrue(Files.exists(SAMPLE_DATA_FILE),
+                "Sample data file not found: " + SAMPLE_DATA_FILE.toAbsolutePath() + " — skipping integration test");
 
         var visitor = new CollectingVisitor();
-        try (var input = new FileInputStream(sampleFile.toFile())) {
+        try (var input = new FileInputStream(SAMPLE_DATA_FILE.toFile())) {
             NlsGmlParser.parse(input, visitor);
         }
 
@@ -629,13 +629,11 @@ class NlsGmlParserTest {
 
     @Test
     void parse_sampleDataFile_spotCheckKunta() throws Exception {
-        var sampleFile = Path.of("../../../SampleData/L3311R.xml");
-        if (!Files.exists(sampleFile)) {
-            return;
-        }
+        Assumptions.assumeTrue(Files.exists(SAMPLE_DATA_FILE),
+                "Sample data file not found: " + SAMPLE_DATA_FILE.toAbsolutePath() + " — skipping integration test");
 
         var visitor = new CollectingVisitor();
-        try (var input = new FileInputStream(sampleFile.toFile())) {
+        try (var input = new FileInputStream(SAMPLE_DATA_FILE.toFile())) {
             NlsGmlParser.parse(input, visitor);
         }
 
@@ -648,13 +646,11 @@ class NlsGmlParserTest {
 
     @Test
     void parse_sampleDataFile_spotCheckOsoitepiste() throws Exception {
-        var sampleFile = Path.of("../../../SampleData/L3311R.xml");
-        if (!Files.exists(sampleFile)) {
-            return;
-        }
+        Assumptions.assumeTrue(Files.exists(SAMPLE_DATA_FILE),
+                "Sample data file not found: " + SAMPLE_DATA_FILE.toAbsolutePath() + " — skipping integration test");
 
         var visitor = new CollectingVisitor();
-        try (var input = new FileInputStream(sampleFile.toFile())) {
+        try (var input = new FileInputStream(SAMPLE_DATA_FILE.toFile())) {
             NlsGmlParser.parse(input, visitor);
         }
 

--- a/Spec/TechnicalDesigns/GIS-Data-Import-and-Schema.md
+++ b/Spec/TechnicalDesigns/GIS-Data-Import-and-Schema.md
@@ -42,7 +42,7 @@ The document contains 140+ feature type collections. Only four are relevant to g
 | `<kunnat>` | `<Kunta>` | Polygon (Alue) | Municipality boundaries |
 | `<tieviivat>` | `<Tieviiva>` | LineString (Murtoviiva) | Road segments with names and address ranges |
 | `<osoitepisteet>` | `<Osoitepiste>` | Point (Piste) | Address points with house numbers |
-| `<paikannnimet>` | `<Paikannimi>` | Point (Piste) | Named places (islands, villages, landmarks) |
+| `<paikannimet>` | `<Paikannimi>` | Point (Piste) | Named places (islands, villages, landmarks) |
 
 ### 1.2 Common Feature Attributes
 


### PR DESCRIPTION
## Summary

- Implement `net.pkhapps.idispatchx.gis.importer.parser` package with a StAX-based GML parser that extracts four NLS topographic feature types (Kunta, Tieviiva, Osoitepiste, Paikannimi) for geocoding
- Add four feature model records, a FeatureType enum, a FeatureVisitor callback interface, and the NlsGmlParser utility class
- Include 21 unit/integration tests covering all feature types, coordinate parsing (2D/3D), nullable fields, error handling, type filtering, and sample data verification (2 Kunta, 83 Tieviiva, 10 Osoitepiste, 273 Paikannimi)
- Fix typo in spec: `paikannnimet` → `paikannimet`

## Test plan

- [x] All 21 new tests pass (`FeatureTypeTest` + `NlsGmlParserTest`)
- [x] All 54 existing tests continue to pass (75 total, BUILD SUCCESS)
- [x] Integration test parses `SampleData/L3311R.xml` and verifies exact feature counts
- [x] Spot-check parsed field values against known entries (Kunta gid=27696440 kuntatunnus=445, Osoitepiste gid=1754319417 numero="427s")

🤖 Generated with [Claude Code](https://claude.com/claude-code)