### PR TITLE
Add vector data import pipeline for GIS Data Importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 # Wrapper JARs (downloaded automatically)
 .mvn/wrapper/maven-wrapper.jar
 **/gradle/wrapper/gradle-wrapper.jar
+
+# IntelliJ IDEA
+.idea/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,20 @@
+{
+    "mcpServers": {
+        "java": {
+            "type": "http",
+            "url": "https://www.javadocs.dev/mcp"
+        },
+        "playwright": {
+            "command": "npx",
+            "args": [
+                "@playwright/mcp@latest"
+            ]
+        },
+        "maven-deps-server": {
+            "command": "npx",
+            "args": [
+                "mcp-maven-deps"
+            ]
+        }
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
         "callsign",
         "callsigns"
     ],
-    "java.compile.nullAnalysis.mode": "disabled"
+    "java.compile.nullAnalysis.mode": "disabled",
+    "java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/Implementation/.mvn/wrapper/maven-wrapper.properties
+++ b/Implementation/.mvn/wrapper/maven-wrapper.properties
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-wrapperVersion=3.3.2
+wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/Implementation/mvnw
+++ b/Implementation/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    https://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.2
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
@@ -100,41 +100,44 @@ die() {
 trim() {
   # MWRAPPER-139:
   #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
-  #   டமற spaces within the string are preserved.
-  printf "%s" "${1}" | tr -d '[:space:]' | tr -d '\r'
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
 }
 
-# parse distributionUrl and optional distributionSha256Sum, requires .teleconfig/wrapper/maven-wrapper.properties
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
   distributionUrl) distributionUrl=$(trim "${value-}") ;;
   distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
-done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
 
 case "${distributionUrl##*/}" in
 maven-mvnd-*bin.*)
-  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/teleconfig/maven/mvnd/
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
   case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
-  *AMD64:CYGWIN* | *AMD64:MINGW*) naда=/windows-amd64 ;;
-  :Darwin*x86_64) naда=/darwin-amd64 ;;
-  :Darwin*arm64) naдаDar=/darwin-aarch64 ;;
-  :Linux*x86_64*) naдаLin=/linux-amd64 ;;
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
   *)
-    naдаFail=true
-    die "mvnd: unsupported distribution architecture: ${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)"
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
     ;;
   esac
-  naда="${naдаDar-${naдаLin-${naда}}}"
-  distributionUrl="${distributionUrl%/*}${naда}/${distributionUrl##*/}"
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
   ;;
-maven-mvnd-*) naдаFail=true die "mvnd: invalid distribution url: $distributionUrl" ;;
-*) MVN_CMD="mvn${0##*mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
 esac
 
 # apply MVNW_REPOURL and calculate MAVEN_HOME
-# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,mvnd-<version>-<platform>}/<hash>
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
 [ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
 distributionUrlName="${distributionUrl##*/}"
 distributionUrlNameMain="${distributionUrlName%.*}"
@@ -212,20 +215,37 @@ elif set_java_home; then
 	  }
 	}
 	END
-  "$JAVACCMD" "$javaSource" || die "failed to compile Downloader.java"
-  "$JAVACMD" -cp "$TMP_DOWNLOAD_DIR" Downloader "$distributionUrl" "$targetZip" || die "failed to download $distributionUrl"
-else
-  die "Unable to download: no wget, curl, or java available"
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
 fi
 
 # If specified, validate the SHA-256 sum of the Maven distribution zip file
 if [ -n "${distributionSha256Sum-}" ]; then
   distributionSha256Result=false
-  if [ "$(echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - 2>/dev/null | cut -d' ' -f2)" = "OK" ]; then
-    distributionSha256Result=true
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
   fi
-  if ! $distributionSha256Result; then
-    die "sha256 checksum mismatch: expected $distributionSha256Sum, got $(sha256sum "$TMP_DOWNLOAD_DIR/$distributionUrlName" | cut -d' ' -f1)"
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
   fi
 fi
 
@@ -233,10 +253,43 @@ fi
 if command -v unzip >/dev/null; then
   unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
 else
-  tar x${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"}f "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
-printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
-mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
 clean || :
 exec_maven "$@"

--- a/Implementation/pom.xml
+++ b/Implementation/pom.xml
@@ -141,7 +141,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.15.0</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
@@ -151,10 +151,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.5.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>                               
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-wrapper-plugin</artifactId>
+                <version>3.3.4</version>
+            </plugin>
+        </plugins>
     </build>
 
     <repositories>

--- a/Implementation/pom.xml
+++ b/Implementation/pom.xml
@@ -107,6 +107,16 @@
                 <artifactId>gt-main</artifactId>
                 <version>${geotools.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-epsg-hsql</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-referencing</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
 
             <!-- Testing -->
             <dependency>

--- a/Implementation/shared/gis-database/pom.xml
+++ b/Implementation/shared/gis-database/pom.xml
@@ -15,6 +15,20 @@
     <name>iDispatchX GIS Database</name>
     <description>Shared Flyway migrations and jOOQ generated code for the GIS database</description>
 
+    <!--
+        NOTE: The docker-maven-plugin uses jffi for Unix socket communication with Docker.
+        On JDK 23+, this produces warnings about sun.misc.Unsafe being terminally deprecated.
+        A fix exists in jffi (Oct 2025 commit) but no stable release includes it yet (latest: 1.3.13).
+        Once jffi 1.3.14+ is released, add this dependency override to the plugin:
+        <dependencies>
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jffi</artifactId>
+                <version>1.3.14</version>
+            </dependency>
+        </dependencies>
+        See: https://github.com/jnr/jffi and JEP 471
+    -->
     <properties>
         <docker-maven-plugin.version>0.48.1</docker-maven-plugin.version>
         <postgis.image>postgis/postgis:17-3.5</postgis.image>

--- a/Implementation/tools/gis-data-importer/README.md
+++ b/Implementation/tools/gis-data-importer/README.md
@@ -1,0 +1,77 @@
+# GIS Data Importer
+
+CLI tool for importing GIS data from the National Land Survey of Finland (Maanmittauslaitos) into iDispatchX.
+
+## Features
+
+- **Vector data import**: Parses GML files (municipality boundaries, road segments, address points, place names) and imports them into PostGIS
+- **Raster tile import**: Converts georeferenced PNG images into a tile directory structure
+
+## Building
+
+From the `Implementation` directory:
+
+```bash
+./mvnw package -pl tools/gis-data-importer -am -DskipTests
+```
+
+This creates a distributable archive at:
+```
+tools/gis-data-importer/target/gis-data-importer-1.0.0-SNAPSHOT-dist.tar.gz
+```
+
+Extract and run using the included shell script:
+```bash
+tar -xzf gis-data-importer-1.0.0-SNAPSHOT-dist.tar.gz
+cd gis-data-importer-1.0.0-SNAPSHOT
+./gis-data-importer.sh [options]
+```
+
+**Requires:** Java 25+
+
+## Usage
+
+### Vector Data Import
+
+Import municipality names from JSON and GML features into PostGIS:
+
+```bash
+./gis-data-importer.sh \
+  --db-url jdbc:postgresql://localhost:5432/idispatchx \
+  --db-user postgres \
+  --db-password secret \
+  --municipalities /path/to/codelist_kunta.json \
+  --input-dir /path/to/gml-files/
+```
+
+Options:
+- `--db-url`, `--db-user`, `--db-password` - PostgreSQL connection (required)
+- `--municipalities <file>` - Municipality reference JSON from koodistot.suomi.fi
+- `--input <file...>` - One or more GML files
+- `--input-dir <dir>` - Directory containing GML files (*.xml)
+- `--features <list>` - Comma-separated feature types to import: `KUNTA`, `TIEVIIVA`, `OSOITEPISTE`, `PAIKANNIMI` (default: all)
+- `--truncate` - Clear existing data before import
+
+### Raster Tile Import
+
+Import georeferenced PNG images as map tiles:
+
+```bash
+./gis-data-importer.sh \
+  --tile-input-dir /path/to/images/ \
+  --tile-dir /path/to/tiles/ \
+  --tile-layer orthophoto
+```
+
+Options:
+- `--tiles <file...>` - One or more PNG files with accompanying world files (.pgw)
+- `--tile-input-dir <dir>` - Directory containing PNG files
+- `--tile-dir <dir>` - Output directory for tiles (required)
+- `--tile-layer <name>` - Layer name (required)
+- `--truncate` - Clear existing layer before import
+
+## Data Sources
+
+- **Municipality boundaries & names**: [koodistot.suomi.fi](https://koodistot.suomi.fi) (JSON) and NLS topographic GML
+- **Road segments, address points, place names**: [National Land Survey of Finland](https://www.maanmittauslaitos.fi/en/maps-and-spatial-data/datasets-and-interfaces/product-descriptions/topographic-database) topographic database GML files
+- **Raster imagery**: Georeferenced PNG with ESRI world files (.pgw)

--- a/Implementation/tools/gis-data-importer/pom.xml
+++ b/Implementation/tools/gis-data-importer/pom.xml
@@ -62,6 +62,14 @@
             <artifactId>gt-main</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>

--- a/Implementation/tools/gis-data-importer/pom.xml
+++ b/Implementation/tools/gis-data-importer/pom.xml
@@ -84,6 +84,38 @@
                     <argLine>-Djava.awt.headless=true</argLine>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>net.pkhapps.idispatchx.gis.importer.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/dist.xml</descriptor>
+                    </descriptors>
+                    <finalName>gis-data-importer-${project.version}</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-distribution</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/Implementation/tools/gis-data-importer/src/main/assembly/dist.xml
+++ b/Implementation/tools/gis-data-importer/src/main/assembly/dist.xml
@@ -1,0 +1,29 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0
+                              http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>dist</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/src/main/scripts</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>gis-data-importer.sh</include>
+            </includes>
+            <fileMode>0755</fileMode>
+        </fileSet>
+    </fileSets>
+
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/lib</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/ImportCommand.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/ImportCommand.java
@@ -54,9 +54,9 @@ public final class ImportCommand {
         this.truncate = truncate;
         this.featureFilter = featureFilter;
         this.municipalityImporter = new MunicipalityImporter(dsl, transformer);
-        this.addressPointImporter = new AddressPointImporter(dsl, transformer);
-        this.roadSegmentImporter = new RoadSegmentImporter(dsl, transformer);
-        this.namedPlaceImporter = new NamedPlaceImporter(dsl, transformer);
+        this.addressPointImporter = new AddressPointImporter(transformer);
+        this.roadSegmentImporter = new RoadSegmentImporter(transformer);
+        this.namedPlaceImporter = new NamedPlaceImporter(transformer);
     }
 
     /**
@@ -129,18 +129,6 @@ public final class ImportCommand {
                             }
                             counter[0]++;
                         }
-
-                        @Override
-                        public void onTieviiva(TieviivaFeature feature) {
-                        }
-
-                        @Override
-                        public void onOsoitepiste(OsoitepisteFeature feature) {
-                        }
-
-                        @Override
-                        public void onPaikannimi(PaikannimiFeature feature) {
-                        }
                     }, EnumSet.of(FeatureType.KUNTA));
                 }
                 logImport(tx, file.getFileName().toString(), "kunta", counter[0], startedAt);
@@ -157,10 +145,6 @@ public final class ImportCommand {
                 var counters = new int[3]; // [tieviiva, osoitepiste, paikannimi]
                 try (var input = new FileInputStream(file.toFile())) {
                     NlsGmlParser.parse(input, new FeatureVisitor() {
-                        @Override
-                        public void onKunta(KuntaFeature feature) {
-                        }
-
                         @Override
                         public void onTieviiva(TieviivaFeature feature) {
                             if (feature.loppupvm() != null) {

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/ImportCommand.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/ImportCommand.java
@@ -1,0 +1,201 @@
+package net.pkhapps.idispatchx.gis.importer;
+
+import net.pkhapps.idispatchx.gis.importer.db.AddressPointImporter;
+import net.pkhapps.idispatchx.gis.importer.db.MunicipalityImporter;
+import net.pkhapps.idispatchx.gis.importer.db.NamedPlaceImporter;
+import net.pkhapps.idispatchx.gis.importer.db.RoadSegmentImporter;
+import net.pkhapps.idispatchx.gis.importer.parser.FeatureType;
+import net.pkhapps.idispatchx.gis.importer.parser.FeatureVisitor;
+import net.pkhapps.idispatchx.gis.importer.parser.MunicipalityJsonParser;
+import net.pkhapps.idispatchx.gis.importer.parser.NlsGmlParser;
+import net.pkhapps.idispatchx.gis.importer.parser.model.KuntaFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.OsoitepisteFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.PaikannimiFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.TieviivaFeature;
+import net.pkhapps.idispatchx.gis.importer.transform.CoordinateTransformer;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static net.pkhapps.idispatchx.gis.database.jooq.tables.ImportLog.IMPORT_LOG;
+
+/**
+ * Orchestrates the 3-pass GIS data import pipeline.
+ * <ol>
+ *   <li>Pass 1: Municipality JSON — names</li>
+ *   <li>Pass 2: GML Kunta features — boundaries</li>
+ *   <li>Pass 3: GML Tieviiva/Osoitepiste/Paikannimi — features</li>
+ * </ol>
+ */
+public final class ImportCommand {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ImportCommand.class);
+
+    private final DSLContext dsl;
+    private final boolean truncate;
+    private final Set<FeatureType> featureFilter;
+
+    private final MunicipalityImporter municipalityImporter;
+    private final AddressPointImporter addressPointImporter;
+    private final RoadSegmentImporter roadSegmentImporter;
+    private final NamedPlaceImporter namedPlaceImporter;
+
+    public ImportCommand(DSLContext dsl, CoordinateTransformer transformer, boolean truncate, Set<FeatureType> featureFilter) {
+        this.dsl = dsl;
+        this.truncate = truncate;
+        this.featureFilter = featureFilter;
+        this.municipalityImporter = new MunicipalityImporter(dsl, transformer);
+        this.addressPointImporter = new AddressPointImporter(dsl, transformer);
+        this.roadSegmentImporter = new RoadSegmentImporter(dsl, transformer);
+        this.namedPlaceImporter = new NamedPlaceImporter(dsl, transformer);
+    }
+
+    /**
+     * Pass 1: Import municipality names from JSON.
+     */
+    public void importMunicipalities(Path jsonFile) throws IOException {
+        LOG.info("Pass 1: Importing municipality names from {}", jsonFile.getFileName());
+        var startedAt = OffsetDateTime.now();
+        try (var input = new FileInputStream(jsonFile.toFile())) {
+            var entries = MunicipalityJsonParser.parse(input);
+            int count = municipalityImporter.importNames(entries);
+            logImport(jsonFile.getFileName().toString(), "municipality_names", count, startedAt);
+        }
+    }
+
+    /**
+     * Passes 2 and 3: Import GML features from all provided files.
+     */
+    public void importGmlFiles(List<Path> gmlFiles) throws Exception {
+        if (truncate) {
+            LOG.info("Truncate mode: resetting tables before import");
+            if (featureFilter.contains(FeatureType.KUNTA)) {
+                municipalityImporter.truncateBoundaries();
+            }
+            if (featureFilter.contains(FeatureType.OSOITEPISTE)) {
+                addressPointImporter.truncate();
+            }
+            if (featureFilter.contains(FeatureType.TIEVIIVA)) {
+                roadSegmentImporter.truncate();
+            }
+            if (featureFilter.contains(FeatureType.PAIKANNIMI)) {
+                namedPlaceImporter.truncate();
+            }
+        }
+
+        // Pass 2: Kunta boundaries
+        if (featureFilter.contains(FeatureType.KUNTA)) {
+            LOG.info("Pass 2: Importing Kunta boundaries from {} file(s)", gmlFiles.size());
+            for (var file : gmlFiles) {
+                var startedAt = OffsetDateTime.now();
+                var counter = new int[]{0};
+                try (var input = new FileInputStream(file.toFile())) {
+                    NlsGmlParser.parse(input, new FeatureVisitor() {
+                        @Override
+                        public void onKunta(KuntaFeature feature) {
+                            if (feature.loppupvm() != null) {
+                                municipalityImporter.deleteByCode(feature.kuntatunnus());
+                            } else {
+                                municipalityImporter.importBoundary(feature);
+                            }
+                            counter[0]++;
+                        }
+
+                        @Override
+                        public void onTieviiva(TieviivaFeature feature) {
+                        }
+
+                        @Override
+                        public void onOsoitepiste(OsoitepisteFeature feature) {
+                        }
+
+                        @Override
+                        public void onPaikannimi(PaikannimiFeature feature) {
+                        }
+                    }, EnumSet.of(FeatureType.KUNTA));
+                }
+                logImport(file.getFileName().toString(), "kunta", counter[0], startedAt);
+            }
+        }
+
+        // Pass 3: Other features
+        var pass3Types = EnumSet.copyOf(featureFilter);
+        pass3Types.remove(FeatureType.KUNTA);
+        if (!pass3Types.isEmpty()) {
+            LOG.info("Pass 3: Importing {} from {} file(s)", pass3Types, gmlFiles.size());
+            for (var file : gmlFiles) {
+                var startedAt = OffsetDateTime.now();
+                var counters = new int[3]; // [tieviiva, osoitepiste, paikannimi]
+                try (var input = new FileInputStream(file.toFile())) {
+                    NlsGmlParser.parse(input, new FeatureVisitor() {
+                        @Override
+                        public void onKunta(KuntaFeature feature) {
+                        }
+
+                        @Override
+                        public void onTieviiva(TieviivaFeature feature) {
+                            if (feature.loppupvm() != null) {
+                                roadSegmentImporter.delete(feature.gid());
+                            } else {
+                                roadSegmentImporter.upsert(feature);
+                            }
+                            counters[0]++;
+                        }
+
+                        @Override
+                        public void onOsoitepiste(OsoitepisteFeature feature) {
+                            if (feature.loppupvm() != null) {
+                                addressPointImporter.delete(feature.gid());
+                            } else {
+                                addressPointImporter.upsert(feature);
+                            }
+                            counters[1]++;
+                        }
+
+                        @Override
+                        public void onPaikannimi(PaikannimiFeature feature) {
+                            if (feature.loppupvm() != null) {
+                                namedPlaceImporter.delete(feature.gid());
+                            } else {
+                                namedPlaceImporter.upsert(feature);
+                            }
+                            counters[2]++;
+                        }
+                    }, pass3Types);
+                }
+
+                // Flush remaining batches
+                roadSegmentImporter.flush();
+                addressPointImporter.flush();
+                namedPlaceImporter.flush();
+
+                var fileName = file.getFileName().toString();
+                if (counters[0] > 0) logImport(fileName, "tieviiva", counters[0], startedAt);
+                if (counters[1] > 0) logImport(fileName, "osoitepiste", counters[1], startedAt);
+                if (counters[2] > 0) logImport(fileName, "paikannimi", counters[2], startedAt);
+            }
+        }
+
+        LOG.info("Import summary: road_segments={}, address_points={}, named_places={}",
+                roadSegmentImporter.totalCount(), addressPointImporter.totalCount(), namedPlaceImporter.totalCount());
+    }
+
+    private void logImport(String filename, String featureType, int recordCount, OffsetDateTime startedAt) {
+        dsl.insertInto(IMPORT_LOG)
+                .set(IMPORT_LOG.FILENAME, filename)
+                .set(IMPORT_LOG.FEATURE_TYPE, featureType)
+                .set(IMPORT_LOG.RECORD_COUNT, recordCount)
+                .set(IMPORT_LOG.STARTED_AT, startedAt)
+                .set(IMPORT_LOG.COMPLETED_AT, OffsetDateTime.now())
+                .execute();
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/Main.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/Main.java
@@ -1,6 +1,9 @@
 package net.pkhapps.idispatchx.gis.importer;
 
+import net.pkhapps.idispatchx.gis.importer.db.DatabaseConnection;
+import net.pkhapps.idispatchx.gis.importer.parser.FeatureType;
 import net.pkhapps.idispatchx.gis.importer.raster.RasterTileImporter;
+import net.pkhapps.idispatchx.gis.importer.transform.CoordinateTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,18 +12,21 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * CLI entry point for the GIS Data Importer.
  * <p>
- * Tile import arguments:
+ * Supports two independent import pipelines that can run in the same invocation:
  * <ul>
- *   <li>{@code --tiles <file>...} — PNG files to import as raster tiles</li>
- *   <li>{@code --tile-input-dir <dir>} — directory containing PNG files to import</li>
- *   <li>{@code --tile-dir <dir>} — base output directory for tiles (required with tile input)</li>
- *   <li>{@code --tile-layer <name>} — layer name (required with tile input)</li>
- *   <li>{@code --truncate} — delete existing layer data before import</li>
+ *   <li>Vector data import: GML features and municipality JSON into PostGIS</li>
+ *   <li>Raster tile import: PNG + world files into filesystem tile directory</li>
  * </ul>
+ *
+ * @see ImportCommand
+ * @see RasterTileImporter
  */
 public final class Main {
 
@@ -30,15 +36,94 @@ public final class Main {
     }
 
     public static void main(String[] args) {
+        // Vector import args
+        var gmlPaths = new ArrayList<Path>();
+        Path gmlInputDir = null;
+        Path municipalitiesFile = null;
+        String dbUrl = null;
+        String dbUser = null;
+        String dbPassword = null;
+        String featuresArg = null;
+
+        // Tile import args
         var tilePaths = new ArrayList<Path>();
         Path tileInputDir = null;
         Path tileDir = null;
         String tileLayer = null;
+
         var truncate = false;
 
+        // Parse arguments
         var i = 0;
         while (i < args.length) {
             switch (args[i]) {
+                case "--input" -> {
+                    i++;
+                    while (i < args.length && !args[i].startsWith("--")) {
+                        gmlPaths.add(Path.of(args[i]));
+                        i++;
+                    }
+                }
+                case "--input-dir" -> {
+                    i++;
+                    if (i < args.length) {
+                        gmlInputDir = Path.of(args[i]);
+                        i++;
+                    } else {
+                        LOG.error("--input-dir requires a directory argument");
+                        System.exit(1);
+                    }
+                }
+                case "--municipalities" -> {
+                    i++;
+                    if (i < args.length) {
+                        municipalitiesFile = Path.of(args[i]);
+                        i++;
+                    } else {
+                        LOG.error("--municipalities requires a file argument");
+                        System.exit(1);
+                    }
+                }
+                case "--db-url" -> {
+                    i++;
+                    if (i < args.length) {
+                        dbUrl = args[i];
+                        i++;
+                    } else {
+                        LOG.error("--db-url requires an argument");
+                        System.exit(1);
+                    }
+                }
+                case "--db-user" -> {
+                    i++;
+                    if (i < args.length) {
+                        dbUser = args[i];
+                        i++;
+                    } else {
+                        LOG.error("--db-user requires an argument");
+                        System.exit(1);
+                    }
+                }
+                case "--db-password" -> {
+                    i++;
+                    if (i < args.length) {
+                        dbPassword = args[i];
+                        i++;
+                    } else {
+                        LOG.error("--db-password requires an argument");
+                        System.exit(1);
+                    }
+                }
+                case "--features" -> {
+                    i++;
+                    if (i < args.length) {
+                        featuresArg = args[i];
+                        i++;
+                    } else {
+                        LOG.error("--features requires a comma-separated list");
+                        System.exit(1);
+                    }
+                }
                 case "--tiles" -> {
                     i++;
                     while (i < args.length && !args[i].startsWith("--")) {
@@ -82,10 +167,26 @@ public final class Main {
                 }
                 default -> {
                     if (args[i].startsWith("--")) {
-                        LOG.info("Ignoring unrecognized option: {}", args[i]);
+                        LOG.warn("Ignoring unrecognized option: {}", args[i]);
                     }
                     i++;
                 }
+            }
+        }
+
+        // Scan GML input directory for XML files
+        if (gmlInputDir != null) {
+            if (!Files.isDirectory(gmlInputDir)) {
+                LOG.error("GML input directory does not exist: {}", gmlInputDir);
+                System.exit(1);
+            }
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(gmlInputDir, "*.xml")) {
+                for (var path : stream) {
+                    gmlPaths.add(path);
+                }
+            } catch (IOException e) {
+                LOG.error("Cannot read GML input directory: {}", e.getMessage());
+                System.exit(1);
             }
         }
 
@@ -105,21 +206,71 @@ public final class Main {
             }
         }
 
-        // Validate
-        if (tilePaths.isEmpty()) {
-            LOG.error("No input files specified. Use --tiles or --tile-input-dir.");
-            System.exit(1);
-        }
-        if (tileDir == null) {
-            LOG.error("--tile-dir is required when tile input is present");
-            System.exit(1);
-        }
-        if (tileLayer == null) {
-            LOG.error("--tile-layer is required when tile input is present");
+        boolean hasVectorInput = !gmlPaths.isEmpty() || municipalitiesFile != null;
+        boolean hasTileInput = !tilePaths.isEmpty();
+
+        if (!hasVectorInput && !hasTileInput) {
+            LOG.error("No input files specified. Use --input, --input-dir, --municipalities, --tiles, or --tile-input-dir.");
             System.exit(1);
         }
 
-        // Execute
+        // Parse feature filter
+        Set<FeatureType> featureFilter = EnumSet.allOf(FeatureType.class);
+        if (featuresArg != null) {
+            featureFilter = EnumSet.noneOf(FeatureType.class);
+            for (var name : featuresArg.split(",")) {
+                featureFilter.add(FeatureType.valueOf(name.trim().toUpperCase()));
+            }
+        }
+
+        // Vector data import
+        if (hasVectorInput) {
+            if (dbUrl == null || dbUser == null || dbPassword == null) {
+                LOG.error("--db-url, --db-user, and --db-password are required for GML/JSON import");
+                System.exit(1);
+            }
+            runVectorImport(dbUrl, dbUser, dbPassword, municipalitiesFile, gmlPaths, truncate, featureFilter);
+        }
+
+        // Tile import
+        if (hasTileInput) {
+            if (tileDir == null) {
+                LOG.error("--tile-dir is required when tile input is present");
+                System.exit(1);
+            }
+            if (tileLayer == null) {
+                LOG.error("--tile-layer is required when tile input is present");
+                System.exit(1);
+            }
+            runTileImport(tileDir, tileLayer, tilePaths, truncate);
+        }
+
+        System.exit(0);
+    }
+
+    private static void runVectorImport(String dbUrl, String dbUser, String dbPassword,
+                                        Path municipalitiesFile, List<Path> gmlPaths,
+                                        boolean truncate, Set<FeatureType> featureFilter) {
+        try (var db = new DatabaseConnection(dbUrl, dbUser, dbPassword)) {
+            var transformer = new CoordinateTransformer();
+            var command = new ImportCommand(db.dsl(), transformer, truncate, featureFilter);
+
+            if (municipalitiesFile != null) {
+                command.importMunicipalities(municipalitiesFile);
+            }
+
+            if (!gmlPaths.isEmpty()) {
+                command.importGmlFiles(gmlPaths);
+            }
+
+            LOG.info("Vector data import complete");
+        } catch (Exception e) {
+            LOG.error("Vector data import failed: {}", e.getMessage(), e);
+            System.exit(1);
+        }
+    }
+
+    private static void runTileImport(Path tileDir, String tileLayer, List<Path> tilePaths, boolean truncate) {
         var importer = new RasterTileImporter(tileDir, tileLayer);
 
         if (truncate) {
@@ -134,7 +285,6 @@ public final class Main {
 
         LOG.info("Importing {} tile source file(s) to {}/{}", tilePaths.size(), tileDir, tileLayer);
         var totalTiles = importer.importFiles(tilePaths);
-        LOG.info("Import complete: {} tiles written", totalTiles);
-        System.exit(0);
+        LOG.info("Tile import complete: {} tiles written", totalTiles);
     }
 }

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/AddressPointImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/AddressPointImporter.java
@@ -1,0 +1,106 @@
+package net.pkhapps.idispatchx.gis.importer.db;
+
+import net.pkhapps.idispatchx.gis.importer.parser.model.OsoitepisteFeature;
+import net.pkhapps.idispatchx.gis.importer.transform.CoordinateTransformer;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.pkhapps.idispatchx.gis.database.jooq.tables.AddressPoint.ADDRESS_POINT;
+
+/**
+ * Imports Osoitepiste (address point) features into the {@code gis.address_point} table.
+ * Accumulates features in a batch and flushes every 1000 rows.
+ */
+public final class AddressPointImporter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AddressPointImporter.class);
+    private static final int BATCH_SIZE = 1000;
+
+    private final DSLContext dsl;
+    private final CoordinateTransformer transformer;
+    private final List<OsoitepisteFeature> batch = new ArrayList<>(BATCH_SIZE);
+    private int totalCount;
+
+    public AddressPointImporter(DSLContext dsl, CoordinateTransformer transformer) {
+        this.dsl = dsl;
+        this.transformer = transformer;
+    }
+
+    /**
+     * Adds a feature to the batch. Flushes when batch size is reached.
+     */
+    public void upsert(OsoitepisteFeature feature) {
+        batch.add(feature);
+        if (batch.size() >= BATCH_SIZE) {
+            flush();
+        }
+    }
+
+    /**
+     * Deletes an address point by its GML gid.
+     */
+    public void delete(long gid) {
+        dsl.deleteFrom(ADDRESS_POINT)
+                .where(ADDRESS_POINT.ID.eq(gid))
+                .execute();
+    }
+
+    /**
+     * Truncates the address_point table for full import mode.
+     */
+    public void truncate() {
+        dsl.truncate(ADDRESS_POINT).execute();
+        LOG.info("Truncated address_point table");
+    }
+
+    /**
+     * Flushes any remaining features in the batch to the database.
+     */
+    public void flush() {
+        if (batch.isEmpty()) return;
+
+        for (var feature : batch) {
+            var point = transformer.transformPoint(feature.pointEasting(), feature.pointNorthing());
+            var pointWkt = "POINT(" + point[1] + " " + point[0] + ")";
+
+            dsl.execute("""
+                            INSERT INTO gis.address_point (id, number, name_fi, name_sv, name_smn, name_sms, name_sme, municipality_code, location, imported_at)
+                            VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, ST_SetSRID(ST_GeomFromText({8}), 4326), NOW())
+                            ON CONFLICT (id) DO UPDATE SET
+                                number = EXCLUDED.number,
+                                name_fi = EXCLUDED.name_fi,
+                                name_sv = EXCLUDED.name_sv,
+                                name_smn = EXCLUDED.name_smn,
+                                name_sms = EXCLUDED.name_sms,
+                                name_sme = EXCLUDED.name_sme,
+                                municipality_code = EXCLUDED.municipality_code,
+                                location = EXCLUDED.location,
+                                imported_at = EXCLUDED.imported_at
+                            """,
+                    DSL.val(feature.gid()),
+                    DSL.val(feature.numero()),
+                    DSL.val(feature.nameFi()),
+                    DSL.val(feature.nameSv()),
+                    DSL.val(feature.nameSmn()),
+                    DSL.val(feature.nameSms()),
+                    DSL.val(feature.nameSme()),
+                    DSL.val(feature.kuntatunnus()),
+                    DSL.val(pointWkt));
+        }
+
+        totalCount += batch.size();
+        batch.clear();
+    }
+
+    /**
+     * Returns the total number of features upserted so far.
+     */
+    public int totalCount() {
+        return totalCount;
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/AddressPointImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/AddressPointImporter.java
@@ -25,7 +25,7 @@ public final class AddressPointImporter {
     private final List<OsoitepisteFeature> batch = new ArrayList<>(BATCH_SIZE);
     private int totalCount;
 
-    public AddressPointImporter(DSLContext dsl, CoordinateTransformer transformer) {
+    public AddressPointImporter(CoordinateTransformer transformer) {
         this.transformer = transformer;
     }
 

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/DatabaseConnection.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/DatabaseConnection.java
@@ -1,0 +1,54 @@
+package net.pkhapps.idispatchx.gis.importer.db;
+
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.postgresql.ds.PGSimpleDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+
+/**
+ * Manages the PostgreSQL database connection for the GIS Data Importer.
+ * Runs Flyway migrations on connect to ensure the schema is current,
+ * and provides a jOOQ {@link DSLContext} for database operations.
+ */
+public final class DatabaseConnection implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DatabaseConnection.class);
+
+    private final DataSource dataSource;
+    private final DSLContext dsl;
+
+    public DatabaseConnection(String dbUrl, String dbUser, String dbPassword) {
+        var ds = new PGSimpleDataSource();
+        ds.setUrl(dbUrl);
+        ds.setUser(dbUser);
+        ds.setPassword(dbPassword);
+        this.dataSource = ds;
+
+        LOG.info("Running Flyway migrations on {}", dbUrl);
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations("classpath:db/migration")
+                .load()
+                .migrate();
+
+        this.dsl = DSL.using(dataSource, SQLDialect.POSTGRES);
+        LOG.info("Database connection established");
+    }
+
+    /**
+     * Returns the jOOQ DSLContext for database operations.
+     */
+    public DSLContext dsl() {
+        return dsl;
+    }
+
+    @Override
+    public void close() {
+        // PGSimpleDataSource does not pool connections; nothing to close.
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/DatabaseConnection.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/DatabaseConnection.java
@@ -8,8 +8,6 @@ import org.postgresql.ds.PGSimpleDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.sql.DataSource;
-
 /**
  * Manages the PostgreSQL database connection for the GIS Data Importer.
  * Runs Flyway migrations on connect to ensure the schema is current,
@@ -19,15 +17,13 @@ public final class DatabaseConnection implements AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(DatabaseConnection.class);
 
-    private final DataSource dataSource;
     private final DSLContext dsl;
 
     public DatabaseConnection(String dbUrl, String dbUser, String dbPassword) {
-        var ds = new PGSimpleDataSource();
-        ds.setUrl(dbUrl);
-        ds.setUser(dbUser);
-        ds.setPassword(dbPassword);
-        this.dataSource = ds;
+        var dataSource = new PGSimpleDataSource();
+        dataSource.setUrl(dbUrl);
+        dataSource.setUser(dbUser);
+        dataSource.setPassword(dbPassword);
 
         LOG.info("Running Flyway migrations on {}", dbUrl);
         Flyway.configure()

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/MunicipalityImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/MunicipalityImporter.java
@@ -1,0 +1,108 @@
+package net.pkhapps.idispatchx.gis.importer.db;
+
+import net.pkhapps.idispatchx.gis.importer.parser.model.KuntaFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.MunicipalityEntry;
+import net.pkhapps.idispatchx.gis.importer.transform.CoordinateTransformer;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static net.pkhapps.idispatchx.gis.database.jooq.tables.Municipality.MUNICIPALITY;
+
+/**
+ * Imports municipality names from JSON and boundary polygons from GML Kunta features
+ * into the {@code gis.municipality} table.
+ */
+public final class MunicipalityImporter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MunicipalityImporter.class);
+
+    private final DSLContext dsl;
+    private final CoordinateTransformer transformer;
+
+    public MunicipalityImporter(DSLContext dsl, CoordinateTransformer transformer) {
+        this.dsl = dsl;
+        this.transformer = transformer;
+    }
+
+    /**
+     * Imports municipality names from parsed JSON entries. Uses UPSERT to preserve existing boundaries.
+     *
+     * @return the number of entries imported
+     */
+    public int importNames(List<MunicipalityEntry> entries) {
+        int count = 0;
+        for (var entry : entries) {
+            dsl.insertInto(MUNICIPALITY)
+                    .set(MUNICIPALITY.MUNICIPALITY_CODE, entry.code())
+                    .set(MUNICIPALITY.NAME_FI, entry.nameFi())
+                    .set(MUNICIPALITY.NAME_SV, entry.nameSv())
+                    .set(MUNICIPALITY.NAME_SMN, entry.nameSmn())
+                    .set(MUNICIPALITY.NAME_SMS, entry.nameSms())
+                    .set(MUNICIPALITY.NAME_SME, entry.nameSme())
+                    .onConflict(MUNICIPALITY.MUNICIPALITY_CODE)
+                    .doUpdate()
+                    .set(MUNICIPALITY.NAME_FI, entry.nameFi())
+                    .set(MUNICIPALITY.NAME_SV, entry.nameSv())
+                    .set(MUNICIPALITY.NAME_SMN, entry.nameSmn())
+                    .set(MUNICIPALITY.NAME_SMS, entry.nameSms())
+                    .set(MUNICIPALITY.NAME_SME, entry.nameSme())
+                    .execute();
+            count++;
+        }
+        LOG.info("Imported {} municipality names", count);
+        return count;
+    }
+
+    /**
+     * Imports a municipality boundary polygon from a GML Kunta feature.
+     * Merges with existing boundary using ST_Union for multi-sheet support.
+     */
+    public void importBoundary(KuntaFeature feature) {
+        var coords = transformer.transformPolygon(feature.polygonCoordinates());
+        var wkt = buildPolygonWkt(coords);
+
+        dsl.execute("""
+                        INSERT INTO gis.municipality (municipality_code, boundary, imported_at)
+                        VALUES ({0}, ST_Multi(ST_GeomFromText({1}, 4326)), NOW())
+                        ON CONFLICT (municipality_code) DO UPDATE SET
+                            boundary = ST_Multi(ST_Union(gis.municipality.boundary, EXCLUDED.boundary)),
+                            imported_at = NOW()
+                        """,
+                DSL.val(feature.kuntatunnus()),
+                DSL.val(wkt));
+    }
+
+    /**
+     * Deletes a municipality by its municipality code (for Kunta features with loppupvm).
+     */
+    public void deleteByCode(String municipalityCode) {
+        dsl.deleteFrom(MUNICIPALITY)
+                .where(MUNICIPALITY.MUNICIPALITY_CODE.eq(municipalityCode))
+                .execute();
+    }
+
+    /**
+     * Resets all municipality boundaries to NULL for full import mode.
+     */
+    public void truncateBoundaries() {
+        dsl.update(MUNICIPALITY)
+                .setNull(MUNICIPALITY.BOUNDARY)
+                .execute();
+        LOG.info("Reset all municipality boundaries to NULL");
+    }
+
+    private static String buildPolygonWkt(double[][] coords) {
+        var sb = new StringBuilder("POLYGON((");
+        for (int i = 0; i < coords.length; i++) {
+            if (i > 0) sb.append(", ");
+            // WKT uses longitude latitude order
+            sb.append(coords[i][1]).append(' ').append(coords[i][0]);
+        }
+        sb.append("))");
+        return sb.toString();
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/NamedPlaceImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/NamedPlaceImporter.java
@@ -1,0 +1,113 @@
+package net.pkhapps.idispatchx.gis.importer.db;
+
+import net.pkhapps.idispatchx.gis.importer.parser.model.PaikannimiFeature;
+import net.pkhapps.idispatchx.gis.importer.transform.CoordinateTransformer;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.pkhapps.idispatchx.gis.database.jooq.tables.NamedPlace.NAMED_PLACE;
+
+/**
+ * Imports Paikannimi (place name) features into the {@code gis.named_place} table.
+ * Resolves municipality by point-in-polygon against {@code gis.municipality} boundaries.
+ * Accumulates features in a batch and flushes every 1000 rows.
+ */
+public final class NamedPlaceImporter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NamedPlaceImporter.class);
+    private static final int BATCH_SIZE = 1000;
+
+    private final DSLContext dsl;
+    private final CoordinateTransformer transformer;
+    private final List<PaikannimiFeature> batch = new ArrayList<>(BATCH_SIZE);
+    private int totalCount;
+
+    public NamedPlaceImporter(DSLContext dsl, CoordinateTransformer transformer) {
+        this.dsl = dsl;
+        this.transformer = transformer;
+    }
+
+    /**
+     * Adds a feature to the batch. Flushes when batch size is reached.
+     */
+    public void upsert(PaikannimiFeature feature) {
+        batch.add(feature);
+        if (batch.size() >= BATCH_SIZE) {
+            flush();
+        }
+    }
+
+    /**
+     * Deletes a named place by its GML gid.
+     */
+    public void delete(long gid) {
+        dsl.deleteFrom(NAMED_PLACE)
+                .where(NAMED_PLACE.ID.eq(gid))
+                .execute();
+    }
+
+    /**
+     * Truncates the named_place table for full import mode.
+     */
+    public void truncate() {
+        dsl.truncate(NAMED_PLACE).execute();
+        LOG.info("Truncated named_place table");
+    }
+
+    /**
+     * Flushes any remaining features in the batch to the database.
+     */
+    public void flush() {
+        if (batch.isEmpty()) return;
+
+        for (var feature : batch) {
+            var point = transformer.transformPoint(feature.pointEasting(), feature.pointNorthing());
+            var pointWkt = "POINT(" + point[1] + " " + point[0] + ")";
+
+            // Resolve municipality via point-in-polygon
+            var municipalityCode = dsl.fetchOne("""
+                            SELECT municipality_code
+                            FROM gis.municipality
+                            WHERE ST_Contains(boundary, ST_SetSRID(ST_GeomFromText({0}), 4326))
+                            LIMIT 1
+                            """,
+                    DSL.val(pointWkt));
+            String resolvedCode = municipalityCode != null ? municipalityCode.get(0, String.class) : null;
+
+            dsl.execute("""
+                            INSERT INTO gis.named_place (id, name, language, place_class, karttanimi_id, municipality_code, location, imported_at)
+                            VALUES ({0}, {1}, {2}, {3}, {4}, {5}, ST_SetSRID(ST_GeomFromText({6}), 4326), NOW())
+                            ON CONFLICT (id) DO UPDATE SET
+                                name = EXCLUDED.name,
+                                language = EXCLUDED.language,
+                                place_class = EXCLUDED.place_class,
+                                karttanimi_id = EXCLUDED.karttanimi_id,
+                                municipality_code = EXCLUDED.municipality_code,
+                                location = EXCLUDED.location,
+                                imported_at = EXCLUDED.imported_at
+                            """,
+                    DSL.val(feature.gid()),
+                    DSL.val(feature.teksti()),
+                    DSL.val(feature.kieli()),
+                    DSL.val(feature.kohdeluokka()),
+                    DSL.val(feature.karttanimiId()),
+                    DSL.val(resolvedCode),
+                    DSL.val(pointWkt));
+        }
+
+        totalCount += batch.size();
+        batch.clear();
+    }
+
+    /**
+     * Returns the total number of features upserted so far.
+     */
+    public int totalCount() {
+        return totalCount;
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/NamedPlaceImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/NamedPlaceImporter.java
@@ -27,7 +27,7 @@ public final class NamedPlaceImporter {
     private final List<PaikannimiFeature> batch = new ArrayList<>(BATCH_SIZE);
     private int totalCount;
 
-    public NamedPlaceImporter(DSLContext dsl, CoordinateTransformer transformer) {
+    public NamedPlaceImporter(CoordinateTransformer transformer) {
         this.transformer = transformer;
     }
 

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/PostGisDsl.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/PostGisDsl.java
@@ -25,13 +25,6 @@ final class PostGisDsl {
     }
 
     /**
-     * {@code ST_SetSRID(geom, srid)} — sets the SRID on an existing geometry.
-     */
-    static Field<Geometry> stSetSrid(Field<Geometry> geom, int srid) {
-        return DSL.function("ST_SetSRID", SQLDataType.GEOMETRY, geom, DSL.val(srid));
-    }
-
-    /**
      * {@code ST_Multi(geom)} — wraps a geometry as a MULTI type.
      */
     static Field<Geometry> stMulti(Field<Geometry> geom) {

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/PostGisDsl.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/PostGisDsl.java
@@ -1,0 +1,90 @@
+package net.pkhapps.idispatchx.gis.importer.db;
+
+import org.jooq.Field;
+import org.jooq.Geometry;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+
+/**
+ * Type-safe jOOQ wrappers for PostGIS functions used by the GIS Data Importer.
+ * <p>
+ * Each method returns a jOOQ {@link Field} that can be used in type-safe query construction.
+ * The function names are strings (unavoidable without a commercial jOOQ license or custom DSL),
+ * but all parameter types and return types are checked at compile time.
+ */
+final class PostGisDsl {
+
+    private PostGisDsl() {
+    }
+
+    /**
+     * {@code ST_GeomFromText(wkt, srid)} — creates a geometry from Well-Known Text with the given SRID.
+     */
+    static Field<Geometry> stGeomFromText(String wkt, int srid) {
+        return DSL.function("ST_GeomFromText", SQLDataType.GEOMETRY, DSL.val(wkt), DSL.val(srid));
+    }
+
+    /**
+     * {@code ST_SetSRID(geom, srid)} — sets the SRID on an existing geometry.
+     */
+    static Field<Geometry> stSetSrid(Field<Geometry> geom, int srid) {
+        return DSL.function("ST_SetSRID", SQLDataType.GEOMETRY, geom, DSL.val(srid));
+    }
+
+    /**
+     * {@code ST_Multi(geom)} — wraps a geometry as a MULTI type.
+     */
+    static Field<Geometry> stMulti(Field<Geometry> geom) {
+        return DSL.function("ST_Multi", SQLDataType.GEOMETRY, geom);
+    }
+
+    /**
+     * {@code ST_Union(a, b)} — returns the geometric union of two geometries.
+     */
+    static Field<Geometry> stUnion(Field<Geometry> a, Field<Geometry> b) {
+        return DSL.function("ST_Union", SQLDataType.GEOMETRY, a, b);
+    }
+
+    /**
+     * {@code ST_Contains(a, b)} — returns true if geometry {@code a} contains geometry {@code b}.
+     */
+    static Field<Boolean> stContains(Field<Geometry> a, Field<Geometry> b) {
+        return DSL.function("ST_Contains", SQLDataType.BOOLEAN, a, b);
+    }
+
+    /**
+     * Builds a WKT POINT string from longitude and latitude.
+     * WKT uses (longitude, latitude) ordering.
+     */
+    static String pointWkt(double latitude, double longitude) {
+        return "POINT(" + longitude + " " + latitude + ")";
+    }
+
+    /**
+     * Builds a WKT LINESTRING string from an array of [latitude, longitude] pairs.
+     * WKT uses (longitude, latitude) ordering.
+     */
+    static String lineStringWkt(double[][] coords) {
+        var sb = new StringBuilder("LINESTRING(");
+        for (int i = 0; i < coords.length; i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(coords[i][1]).append(' ').append(coords[i][0]);
+        }
+        sb.append(')');
+        return sb.toString();
+    }
+
+    /**
+     * Builds a WKT POLYGON string from an array of [latitude, longitude] pairs.
+     * WKT uses (longitude, latitude) ordering.
+     */
+    static String polygonWkt(double[][] coords) {
+        var sb = new StringBuilder("POLYGON((");
+        for (int i = 0; i < coords.length; i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(coords[i][1]).append(' ').append(coords[i][0]);
+        }
+        sb.append("))");
+        return sb.toString();
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/RoadSegmentImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/RoadSegmentImporter.java
@@ -3,7 +3,6 @@ package net.pkhapps.idispatchx.gis.importer.db;
 import net.pkhapps.idispatchx.gis.importer.parser.model.TieviivaFeature;
 import net.pkhapps.idispatchx.gis.importer.transform.CoordinateTransformer;
 import org.jooq.DSLContext;
-import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static net.pkhapps.idispatchx.gis.database.jooq.tables.RoadSegment.ROAD_SEGMENT;
+import static net.pkhapps.idispatchx.gis.importer.db.PostGisDsl.*;
 
 /**
  * Imports Tieviiva (road segment) features into the {@code gis.road_segment} table.
@@ -68,45 +68,45 @@ public final class RoadSegmentImporter {
 
         for (var feature : batch) {
             var coords = transformer.transformLineString(feature.lineCoordinates());
-            var lineWkt = buildLineStringWkt(coords);
+            var geometry = stGeomFromText(lineStringWkt(coords), 4326);
 
-            tx.execute("""
-                            INSERT INTO gis.road_segment (id, road_class, surface_type, administrative_class, one_way, name_fi, name_sv, name_smn, name_sms, name_sme, min_address_left, max_address_left, min_address_right, max_address_right, municipality_code, geometry, imported_at)
-                            VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}, {12}, {13}, {14}, ST_SetSRID(ST_GeomFromText({15}), 4326), NOW())
-                            ON CONFLICT (id) DO UPDATE SET
-                                road_class = EXCLUDED.road_class,
-                                surface_type = EXCLUDED.surface_type,
-                                administrative_class = EXCLUDED.administrative_class,
-                                one_way = EXCLUDED.one_way,
-                                name_fi = EXCLUDED.name_fi,
-                                name_sv = EXCLUDED.name_sv,
-                                name_smn = EXCLUDED.name_smn,
-                                name_sms = EXCLUDED.name_sms,
-                                name_sme = EXCLUDED.name_sme,
-                                min_address_left = EXCLUDED.min_address_left,
-                                max_address_left = EXCLUDED.max_address_left,
-                                min_address_right = EXCLUDED.min_address_right,
-                                max_address_right = EXCLUDED.max_address_right,
-                                municipality_code = EXCLUDED.municipality_code,
-                                geometry = EXCLUDED.geometry,
-                                imported_at = EXCLUDED.imported_at
-                            """,
-                    DSL.val(feature.gid()),
-                    DSL.val(feature.kohdeluokka()),
-                    DSL.val((short) feature.paallyste()),
-                    DSL.val(feature.hallinnollinenLuokka() != null ? feature.hallinnollinenLuokka().shortValue() : null),
-                    DSL.val((short) feature.yksisuuntaisuus()),
-                    DSL.val(feature.nameFi()),
-                    DSL.val(feature.nameSv()),
-                    DSL.val(feature.nameSmn()),
-                    DSL.val(feature.nameSms()),
-                    DSL.val(feature.nameSme()),
-                    DSL.val(feature.minAddressLeft()),
-                    DSL.val(feature.maxAddressLeft()),
-                    DSL.val(feature.minAddressRight()),
-                    DSL.val(feature.maxAddressRight()),
-                    DSL.val(feature.kuntatunnus()),
-                    DSL.val(lineWkt));
+            tx.insertInto(ROAD_SEGMENT)
+                    .set(ROAD_SEGMENT.ID, feature.gid())
+                    .set(ROAD_SEGMENT.ROAD_CLASS, feature.kohdeluokka())
+                    .set(ROAD_SEGMENT.SURFACE_TYPE, (short) feature.paallyste())
+                    .set(ROAD_SEGMENT.ADMINISTRATIVE_CLASS,
+                            feature.hallinnollinenLuokka() != null ? feature.hallinnollinenLuokka().shortValue() : null)
+                    .set(ROAD_SEGMENT.ONE_WAY, (short) feature.yksisuuntaisuus())
+                    .set(ROAD_SEGMENT.NAME_FI, feature.nameFi())
+                    .set(ROAD_SEGMENT.NAME_SV, feature.nameSv())
+                    .set(ROAD_SEGMENT.NAME_SMN, feature.nameSmn())
+                    .set(ROAD_SEGMENT.NAME_SMS, feature.nameSms())
+                    .set(ROAD_SEGMENT.NAME_SME, feature.nameSme())
+                    .set(ROAD_SEGMENT.MIN_ADDRESS_LEFT, feature.minAddressLeft())
+                    .set(ROAD_SEGMENT.MAX_ADDRESS_LEFT, feature.maxAddressLeft())
+                    .set(ROAD_SEGMENT.MIN_ADDRESS_RIGHT, feature.minAddressRight())
+                    .set(ROAD_SEGMENT.MAX_ADDRESS_RIGHT, feature.maxAddressRight())
+                    .set(ROAD_SEGMENT.MUNICIPALITY_CODE, feature.kuntatunnus())
+                    .set(ROAD_SEGMENT.GEOMETRY, geometry)
+                    .onConflict(ROAD_SEGMENT.ID)
+                    .doUpdate()
+                    .set(ROAD_SEGMENT.ROAD_CLASS, feature.kohdeluokka())
+                    .set(ROAD_SEGMENT.SURFACE_TYPE, (short) feature.paallyste())
+                    .set(ROAD_SEGMENT.ADMINISTRATIVE_CLASS,
+                            feature.hallinnollinenLuokka() != null ? feature.hallinnollinenLuokka().shortValue() : null)
+                    .set(ROAD_SEGMENT.ONE_WAY, (short) feature.yksisuuntaisuus())
+                    .set(ROAD_SEGMENT.NAME_FI, feature.nameFi())
+                    .set(ROAD_SEGMENT.NAME_SV, feature.nameSv())
+                    .set(ROAD_SEGMENT.NAME_SMN, feature.nameSmn())
+                    .set(ROAD_SEGMENT.NAME_SMS, feature.nameSms())
+                    .set(ROAD_SEGMENT.NAME_SME, feature.nameSme())
+                    .set(ROAD_SEGMENT.MIN_ADDRESS_LEFT, feature.minAddressLeft())
+                    .set(ROAD_SEGMENT.MAX_ADDRESS_LEFT, feature.maxAddressLeft())
+                    .set(ROAD_SEGMENT.MIN_ADDRESS_RIGHT, feature.minAddressRight())
+                    .set(ROAD_SEGMENT.MAX_ADDRESS_RIGHT, feature.maxAddressRight())
+                    .set(ROAD_SEGMENT.MUNICIPALITY_CODE, feature.kuntatunnus())
+                    .set(ROAD_SEGMENT.GEOMETRY, geometry)
+                    .execute();
         }
 
         totalCount += batch.size();
@@ -125,16 +125,5 @@ public final class RoadSegmentImporter {
      */
     public int batchSize() {
         return batch.size();
-    }
-
-    private static String buildLineStringWkt(double[][] coords) {
-        var sb = new StringBuilder("LINESTRING(");
-        for (int i = 0; i < coords.length; i++) {
-            if (i > 0) sb.append(", ");
-            // WKT uses longitude latitude order
-            sb.append(coords[i][1]).append(' ').append(coords[i][0]);
-        }
-        sb.append(')');
-        return sb.toString();
     }
 }

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/RoadSegmentImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/RoadSegmentImporter.java
@@ -21,54 +21,56 @@ public final class RoadSegmentImporter {
     private static final Logger LOG = LoggerFactory.getLogger(RoadSegmentImporter.class);
     private static final int BATCH_SIZE = 1000;
 
-    private final DSLContext dsl;
     private final CoordinateTransformer transformer;
     private final List<TieviivaFeature> batch = new ArrayList<>(BATCH_SIZE);
     private int totalCount;
 
     public RoadSegmentImporter(DSLContext dsl, CoordinateTransformer transformer) {
-        this.dsl = dsl;
         this.transformer = transformer;
     }
 
     /**
-     * Adds a feature to the batch. Flushes when batch size is reached.
+     * Adds a feature to the batch. Does not perform any database operations.
+     * Call {@link #flush(DSLContext)} to write accumulated features.
      */
     public void upsert(TieviivaFeature feature) {
         batch.add(feature);
-        if (batch.size() >= BATCH_SIZE) {
-            flush();
-        }
     }
 
     /**
      * Deletes a road segment by its GML gid.
+     *
+     * @param tx the transactional DSLContext
      */
-    public void delete(long gid) {
-        dsl.deleteFrom(ROAD_SEGMENT)
+    public void delete(DSLContext tx, long gid) {
+        tx.deleteFrom(ROAD_SEGMENT)
                 .where(ROAD_SEGMENT.ID.eq(gid))
                 .execute();
     }
 
     /**
      * Truncates the road_segment table for full import mode.
+     *
+     * @param tx the transactional DSLContext
      */
-    public void truncate() {
-        dsl.truncate(ROAD_SEGMENT).execute();
+    public void truncate(DSLContext tx) {
+        tx.truncate(ROAD_SEGMENT).execute();
         LOG.info("Truncated road_segment table");
     }
 
     /**
      * Flushes any remaining features in the batch to the database.
+     *
+     * @param tx the transactional DSLContext
      */
-    public void flush() {
+    public void flush(DSLContext tx) {
         if (batch.isEmpty()) return;
 
         for (var feature : batch) {
             var coords = transformer.transformLineString(feature.lineCoordinates());
             var lineWkt = buildLineStringWkt(coords);
 
-            dsl.execute("""
+            tx.execute("""
                             INSERT INTO gis.road_segment (id, road_class, surface_type, administrative_class, one_way, name_fi, name_sv, name_smn, name_sms, name_sme, min_address_left, max_address_left, min_address_right, max_address_right, municipality_code, geometry, imported_at)
                             VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}, {12}, {13}, {14}, ST_SetSRID(ST_GeomFromText({15}), 4326), NOW())
                             ON CONFLICT (id) DO UPDATE SET
@@ -116,6 +118,13 @@ public final class RoadSegmentImporter {
      */
     public int totalCount() {
         return totalCount;
+    }
+
+    /**
+     * Returns the current batch size (for triggering flushes externally).
+     */
+    public int batchSize() {
+        return batch.size();
     }
 
     private static String buildLineStringWkt(double[][] coords) {

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/RoadSegmentImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/RoadSegmentImporter.java
@@ -25,7 +25,7 @@ public final class RoadSegmentImporter {
     private final List<TieviivaFeature> batch = new ArrayList<>(BATCH_SIZE);
     private int totalCount;
 
-    public RoadSegmentImporter(DSLContext dsl, CoordinateTransformer transformer) {
+    public RoadSegmentImporter(CoordinateTransformer transformer) {
         this.transformer = transformer;
     }
 

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/RoadSegmentImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/db/RoadSegmentImporter.java
@@ -1,0 +1,131 @@
+package net.pkhapps.idispatchx.gis.importer.db;
+
+import net.pkhapps.idispatchx.gis.importer.parser.model.TieviivaFeature;
+import net.pkhapps.idispatchx.gis.importer.transform.CoordinateTransformer;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.pkhapps.idispatchx.gis.database.jooq.tables.RoadSegment.ROAD_SEGMENT;
+
+/**
+ * Imports Tieviiva (road segment) features into the {@code gis.road_segment} table.
+ * Accumulates features in a batch and flushes every 1000 rows.
+ */
+public final class RoadSegmentImporter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RoadSegmentImporter.class);
+    private static final int BATCH_SIZE = 1000;
+
+    private final DSLContext dsl;
+    private final CoordinateTransformer transformer;
+    private final List<TieviivaFeature> batch = new ArrayList<>(BATCH_SIZE);
+    private int totalCount;
+
+    public RoadSegmentImporter(DSLContext dsl, CoordinateTransformer transformer) {
+        this.dsl = dsl;
+        this.transformer = transformer;
+    }
+
+    /**
+     * Adds a feature to the batch. Flushes when batch size is reached.
+     */
+    public void upsert(TieviivaFeature feature) {
+        batch.add(feature);
+        if (batch.size() >= BATCH_SIZE) {
+            flush();
+        }
+    }
+
+    /**
+     * Deletes a road segment by its GML gid.
+     */
+    public void delete(long gid) {
+        dsl.deleteFrom(ROAD_SEGMENT)
+                .where(ROAD_SEGMENT.ID.eq(gid))
+                .execute();
+    }
+
+    /**
+     * Truncates the road_segment table for full import mode.
+     */
+    public void truncate() {
+        dsl.truncate(ROAD_SEGMENT).execute();
+        LOG.info("Truncated road_segment table");
+    }
+
+    /**
+     * Flushes any remaining features in the batch to the database.
+     */
+    public void flush() {
+        if (batch.isEmpty()) return;
+
+        for (var feature : batch) {
+            var coords = transformer.transformLineString(feature.lineCoordinates());
+            var lineWkt = buildLineStringWkt(coords);
+
+            dsl.execute("""
+                            INSERT INTO gis.road_segment (id, road_class, surface_type, administrative_class, one_way, name_fi, name_sv, name_smn, name_sms, name_sme, min_address_left, max_address_left, min_address_right, max_address_right, municipality_code, geometry, imported_at)
+                            VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}, {12}, {13}, {14}, ST_SetSRID(ST_GeomFromText({15}), 4326), NOW())
+                            ON CONFLICT (id) DO UPDATE SET
+                                road_class = EXCLUDED.road_class,
+                                surface_type = EXCLUDED.surface_type,
+                                administrative_class = EXCLUDED.administrative_class,
+                                one_way = EXCLUDED.one_way,
+                                name_fi = EXCLUDED.name_fi,
+                                name_sv = EXCLUDED.name_sv,
+                                name_smn = EXCLUDED.name_smn,
+                                name_sms = EXCLUDED.name_sms,
+                                name_sme = EXCLUDED.name_sme,
+                                min_address_left = EXCLUDED.min_address_left,
+                                max_address_left = EXCLUDED.max_address_left,
+                                min_address_right = EXCLUDED.min_address_right,
+                                max_address_right = EXCLUDED.max_address_right,
+                                municipality_code = EXCLUDED.municipality_code,
+                                geometry = EXCLUDED.geometry,
+                                imported_at = EXCLUDED.imported_at
+                            """,
+                    DSL.val(feature.gid()),
+                    DSL.val(feature.kohdeluokka()),
+                    DSL.val((short) feature.paallyste()),
+                    DSL.val(feature.hallinnollinenLuokka() != null ? feature.hallinnollinenLuokka().shortValue() : null),
+                    DSL.val((short) feature.yksisuuntaisuus()),
+                    DSL.val(feature.nameFi()),
+                    DSL.val(feature.nameSv()),
+                    DSL.val(feature.nameSmn()),
+                    DSL.val(feature.nameSms()),
+                    DSL.val(feature.nameSme()),
+                    DSL.val(feature.minAddressLeft()),
+                    DSL.val(feature.maxAddressLeft()),
+                    DSL.val(feature.minAddressRight()),
+                    DSL.val(feature.maxAddressRight()),
+                    DSL.val(feature.kuntatunnus()),
+                    DSL.val(lineWkt));
+        }
+
+        totalCount += batch.size();
+        batch.clear();
+    }
+
+    /**
+     * Returns the total number of features upserted so far.
+     */
+    public int totalCount() {
+        return totalCount;
+    }
+
+    private static String buildLineStringWkt(double[][] coords) {
+        var sb = new StringBuilder("LINESTRING(");
+        for (int i = 0; i < coords.length; i++) {
+            if (i > 0) sb.append(", ");
+            // WKT uses longitude latitude order
+            sb.append(coords[i][1]).append(' ').append(coords[i][0]);
+        }
+        sb.append(')');
+        return sb.toString();
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/FeatureVisitor.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/FeatureVisitor.java
@@ -7,26 +7,32 @@ import net.pkhapps.idispatchx.gis.importer.parser.model.TieviivaFeature;
 
 /**
  * Callback interface for receiving parsed GML features from {@link NlsGmlParser}.
+ * All methods have default empty implementations so callers only need to override
+ * the methods for features they care about.
  */
 public interface FeatureVisitor {
 
     /**
      * Called when a Kunta (municipality boundary) feature has been parsed.
      */
-    void onKunta(KuntaFeature feature);
+    default void onKunta(KuntaFeature feature) {
+    }
 
     /**
      * Called when a Tieviiva (road segment) feature has been parsed.
      */
-    void onTieviiva(TieviivaFeature feature);
+    default void onTieviiva(TieviivaFeature feature) {
+    }
 
     /**
      * Called when an Osoitepiste (address point) feature has been parsed.
      */
-    void onOsoitepiste(OsoitepisteFeature feature);
+    default void onOsoitepiste(OsoitepisteFeature feature) {
+    }
 
     /**
      * Called when a Paikannimi (place name) feature has been parsed.
      */
-    void onPaikannimi(PaikannimiFeature feature);
+    default void onPaikannimi(PaikannimiFeature feature) {
+    }
 }

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/MunicipalityJsonParser.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/MunicipalityJsonParser.java
@@ -1,0 +1,122 @@
+package net.pkhapps.idispatchx.gis.importer.parser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.pkhapps.idispatchx.gis.importer.parser.model.MunicipalityEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Streaming JSON parser for municipality reference data from koodistot.suomi.fi.
+ * Navigates directly to the {@code codes} array and extracts VALID municipality entries.
+ */
+public final class MunicipalityJsonParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MunicipalityJsonParser.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private MunicipalityJsonParser() {
+    }
+
+    /**
+     * Parses the municipality reference JSON and returns all valid municipality entries.
+     *
+     * @param input the JSON input stream
+     * @return list of parsed municipality entries with status VALID
+     * @throws IOException if parsing fails
+     */
+    public static List<MunicipalityEntry> parse(InputStream input) throws IOException {
+        var entries = new ArrayList<MunicipalityEntry>();
+        try (var parser = MAPPER.getFactory().createParser(input)) {
+            navigateToCodesArray(parser);
+            if (parser.currentToken() == JsonToken.START_ARRAY) {
+                while (parser.nextToken() != JsonToken.END_ARRAY) {
+                    if (parser.currentToken() == JsonToken.START_OBJECT) {
+                        var entry = parseCodeEntry(parser);
+                        if (entry != null) {
+                            entries.add(entry);
+                        }
+                    }
+                }
+            }
+        }
+        LOG.info("Parsed {} valid municipality entries from JSON", entries.size());
+        return entries;
+    }
+
+    private static void navigateToCodesArray(JsonParser parser) throws IOException {
+        // Navigate to the top-level "codes" field
+        while (parser.nextToken() != null) {
+            if (parser.currentToken() == JsonToken.FIELD_NAME && "codes".equals(parser.currentName())) {
+                parser.nextToken(); // move to START_ARRAY
+                return;
+            }
+            // Skip nested objects/arrays that aren't "codes"
+            if (parser.currentToken() == JsonToken.START_OBJECT || parser.currentToken() == JsonToken.START_ARRAY) {
+                if (parser.currentToken() == JsonToken.START_ARRAY && parser.currentName() != null && !"codes".equals(parser.currentName())) {
+                    parser.skipChildren();
+                }
+            }
+        }
+    }
+
+    private static MunicipalityEntry parseCodeEntry(JsonParser parser) throws IOException {
+        String codeValue = null;
+        String status = null;
+        String nameFi = null;
+        String nameSv = null;
+        String nameSmn = null;
+        String nameSms = null;
+        String nameSme = null;
+
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            if (parser.currentToken() == JsonToken.FIELD_NAME) {
+                var fieldName = parser.currentName();
+                parser.nextToken();
+                switch (fieldName) {
+                    case "codeValue" -> codeValue = parser.getText();
+                    case "status" -> status = parser.getText();
+                    case "prefLabel" -> {
+                        if (parser.currentToken() == JsonToken.START_OBJECT) {
+                            while (parser.nextToken() != JsonToken.END_OBJECT) {
+                                if (parser.currentToken() == JsonToken.FIELD_NAME) {
+                                    var lang = parser.currentName();
+                                    parser.nextToken();
+                                    switch (lang) {
+                                        case "fi" -> nameFi = parser.getText();
+                                        case "sv" -> nameSv = parser.getText();
+                                        case "smn" -> nameSmn = parser.getText();
+                                        case "sms" -> nameSms = parser.getText();
+                                        case "se" -> nameSme = parser.getText(); // ISO 639-1 "se" → "sme"
+                                        default -> { /* ignore other languages like "en" */ }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    default -> {
+                        if (parser.currentToken() == JsonToken.START_OBJECT
+                                || parser.currentToken() == JsonToken.START_ARRAY) {
+                            parser.skipChildren();
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!"VALID".equals(status)) {
+            return null;
+        }
+        if (codeValue == null) {
+            LOG.warn("Skipping VALID entry without codeValue");
+            return null;
+        }
+        return new MunicipalityEntry(codeValue, nameFi, nameSv, nameSmn, nameSms, nameSme);
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/MunicipalityJsonParser.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/MunicipalityJsonParser.java
@@ -7,6 +7,8 @@ import net.pkhapps.idispatchx.gis.importer.parser.model.MunicipalityEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -66,7 +68,7 @@ public final class MunicipalityJsonParser {
         }
     }
 
-    private static MunicipalityEntry parseCodeEntry(JsonParser parser) throws IOException {
+    private static @Nullable MunicipalityEntry parseCodeEntry(JsonParser parser) throws IOException {
         String codeValue = null;
         String status = null;
         String nameFi = null;

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/MunicipalityEntry.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/parser/model/MunicipalityEntry.java
@@ -1,0 +1,23 @@
+package net.pkhapps.idispatchx.gis.importer.parser.model;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Parsed municipality entry from the municipality reference JSON file.
+ *
+ * @param code    3-digit municipality code
+ * @param nameFi  Finnish name
+ * @param nameSv  Swedish name
+ * @param nameSmn Inari Sami name
+ * @param nameSms Skolt Sami name
+ * @param nameSme Northern Sami name
+ */
+public record MunicipalityEntry(
+        String code,
+        @Nullable String nameFi,
+        @Nullable String nameSv,
+        @Nullable String nameSmn,
+        @Nullable String nameSms,
+        @Nullable String nameSme
+) {
+}

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/transform/CoordinateTransformer.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/transform/CoordinateTransformer.java
@@ -1,0 +1,105 @@
+package net.pkhapps.idispatchx.gis.importer.transform;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.referencing.CRS;
+/**
+ * Transforms coordinates from EPSG:3067 (EUREF-FIN / TM35FIN) to EPSG:4326 (WGS 84).
+ * Validates that transformed coordinates fall within Finland's bounds.
+ */
+public final class CoordinateTransformer {
+
+    private static final double MIN_LATITUDE = 58.84;
+    private static final double MAX_LATITUDE = 70.09;
+    private static final double MIN_LONGITUDE = 19.08;
+    private static final double MAX_LONGITUDE = 31.59;
+
+    private final MathTransform transform;
+
+    public CoordinateTransformer() {
+        try {
+            CoordinateReferenceSystem sourceCRS = CRS.decode("EPSG:3067");
+            CoordinateReferenceSystem targetCRS = CRS.decode("EPSG:4326");
+            this.transform = CRS.findMathTransform(sourceCRS, targetCRS, true);
+        } catch (FactoryException e) {
+            throw new IllegalStateException("Failed to initialize coordinate transformation", e);
+        }
+    }
+
+    /**
+     * Transforms a single point from EPSG:3067 to EPSG:4326.
+     *
+     * @param easting  the easting coordinate in EPSG:3067
+     * @param northing the northing coordinate in EPSG:3067
+     * @return {@code double[]{latitude, longitude}} in EPSG:4326
+     * @throws IllegalArgumentException if the transformed coordinates are outside Finland's bounds
+     */
+    public double[] transformPoint(double easting, double northing) {
+        var source = new double[]{easting, northing};
+        var target = new double[2];
+        try {
+            transform.transform(source, 0, target, 0, 1);
+        } catch (TransformException e) {
+            throw new IllegalArgumentException("Failed to transform point (" + easting + ", " + northing + ")", e);
+        }
+        // GeoTools CRS.decode("EPSG:4326") returns coordinates as (lat, lon)
+        double latitude = target[0];
+        double longitude = target[1];
+        validateBounds(latitude, longitude);
+        return new double[]{latitude, longitude};
+    }
+
+    /**
+     * Transforms a linestring from EPSG:3067 to EPSG:4326.
+     *
+     * @param coords array of [easting, northing] pairs in EPSG:3067
+     * @return array of [latitude, longitude] pairs in EPSG:4326
+     * @throws IllegalArgumentException if any transformed coordinate is outside Finland's bounds
+     */
+    public double[][] transformLineString(double[][] coords) {
+        return transformCoordArray(coords);
+    }
+
+    /**
+     * Transforms a polygon from EPSG:3067 to EPSG:4326.
+     *
+     * @param coords array of [easting, northing] pairs in EPSG:3067
+     * @return array of [latitude, longitude] pairs in EPSG:4326
+     * @throws IllegalArgumentException if any transformed coordinate is outside Finland's bounds
+     */
+    public double[][] transformPolygon(double[][] coords) {
+        return transformCoordArray(coords);
+    }
+
+    private double[][] transformCoordArray(double[][] coords) {
+        var source = new double[coords.length * 2];
+        for (int i = 0; i < coords.length; i++) {
+            source[i * 2] = coords[i][0];
+            source[i * 2 + 1] = coords[i][1];
+        }
+        var target = new double[source.length];
+        try {
+            transform.transform(source, 0, target, 0, coords.length);
+        } catch (TransformException e) {
+            throw new IllegalArgumentException("Failed to transform coordinates", e);
+        }
+        var result = new double[coords.length][];
+        for (int i = 0; i < coords.length; i++) {
+            double latitude = target[i * 2];
+            double longitude = target[i * 2 + 1];
+            validateBounds(latitude, longitude);
+            result[i] = new double[]{latitude, longitude};
+        }
+        return result;
+    }
+
+    private void validateBounds(double latitude, double longitude) {
+        if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE
+                || longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE) {
+            throw new IllegalArgumentException(
+                    "Transformed coordinate outside Finland bounds: lat=" + latitude + ", lon=" + longitude);
+        }
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/main/scripts/gis-data-importer.sh
+++ b/Implementation/tools/gis-data-importer/src/main/scripts/gis-data-importer.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# GIS Data Importer - Launch script for Linux
+#
+# Usage: ./gis-data-importer.sh [options]
+#
+# Requires: Java 25+ installed and available in PATH
+#
+
+set -e
+
+# Resolve the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/lib"
+
+# Check that lib directory exists
+if [ ! -d "${LIB_DIR}" ]; then
+    echo "Error: lib directory not found at ${LIB_DIR}" >&2
+    exit 1
+fi
+
+# Build classpath from all JARs in lib/
+CLASSPATH=""
+for jar in "${LIB_DIR}"/*.jar; do
+    if [ -z "${CLASSPATH}" ]; then
+        CLASSPATH="${jar}"
+    else
+        CLASSPATH="${CLASSPATH}:${jar}"
+    fi
+done
+
+if [ -z "${CLASSPATH}" ]; then
+    echo "Error: No JAR files found in ${LIB_DIR}" >&2
+    exit 1
+fi
+
+# Default JVM options (can be overridden via JAVA_OPTS environment variable)
+DEFAULT_JAVA_OPTS="--enable-preview -Djava.awt.headless=true"
+
+# Run the importer
+exec java ${DEFAULT_JAVA_OPTS} ${JAVA_OPTS:-} -cp "${CLASSPATH}" net.pkhapps.idispatchx.gis.importer.Main "$@"

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/GisDataImporterIntegrationTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/GisDataImporterIntegrationTest.java
@@ -72,19 +72,6 @@ class GisDataImporterIntegrationTest {
     }
 
     @Test
-    void coordinateTransform_sampleOsoitepiste_approximateLocation() throws Exception {
-        Assumptions.assumeTrue(Files.exists(SAMPLE_GML),
-                "Sample GML not found: " + SAMPLE_GML.toAbsolutePath());
-
-        var transformer = new CoordinateTransformer();
-        // Kuggö address point from sample data
-        var result = transformer.transformPoint(231221.828, 6677931.943);
-        // Should be in the Turku archipelago area: roughly lat ~60.1, lon ~22.2
-        assertEquals(60.1, result[0], 0.2, "Latitude should be near 60.1");
-        assertEquals(22.2, result[1], 0.2, "Longitude should be near 22.2");
-    }
-
-    @Test
     void municipalityJson_sampleFile_spotCheckEntries() throws Exception {
         Assumptions.assumeTrue(Files.exists(SAMPLE_JSON),
                 "Sample JSON not found: " + SAMPLE_JSON.toAbsolutePath());

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/GisDataImporterIntegrationTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/GisDataImporterIntegrationTest.java
@@ -1,0 +1,145 @@
+package net.pkhapps.idispatchx.gis.importer;
+
+import net.pkhapps.idispatchx.gis.importer.parser.FeatureVisitor;
+import net.pkhapps.idispatchx.gis.importer.parser.MunicipalityJsonParser;
+import net.pkhapps.idispatchx.gis.importer.parser.NlsGmlParser;
+import net.pkhapps.idispatchx.gis.importer.parser.model.KuntaFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.OsoitepisteFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.PaikannimiFeature;
+import net.pkhapps.idispatchx.gis.importer.parser.model.TieviivaFeature;
+import net.pkhapps.idispatchx.gis.importer.transform.CoordinateTransformer;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests using sample data files.
+ * These tests verify coordinate transformation on actual parsed GML features
+ * and municipality JSON parsing with the real data file.
+ * Tests are skipped if sample data files are not present.
+ */
+class GisDataImporterIntegrationTest {
+
+    private static final Path SAMPLE_GML = Path.of("../../../SampleData/L3311R.xml");
+    private static final Path SAMPLE_JSON = Path.of("../../../SampleData/codelist_kunta_1_20250101.json");
+
+    @Test
+    void coordinateTransform_allSampleFeatures_withinFinlandBounds() throws Exception {
+        Assumptions.assumeTrue(Files.exists(SAMPLE_GML),
+                "Sample GML not found: " + SAMPLE_GML.toAbsolutePath());
+
+        var transformer = new CoordinateTransformer();
+        var visitor = new CollectingVisitor();
+
+        try (var input = new FileInputStream(SAMPLE_GML.toFile())) {
+            NlsGmlParser.parse(input, visitor);
+        }
+
+        // Transform all Kunta polygons
+        for (var kunta : visitor.kunnat) {
+            var coords = transformer.transformPolygon(kunta.polygonCoordinates());
+            for (var point : coords) {
+                assertValidFinlandCoordinate(point, "Kunta gid=" + kunta.gid());
+            }
+        }
+
+        // Transform all Osoitepiste points
+        for (var op : visitor.osoitepisteet) {
+            var point = transformer.transformPoint(op.pointEasting(), op.pointNorthing());
+            assertValidFinlandCoordinate(point, "Osoitepiste gid=" + op.gid());
+        }
+
+        // Transform all Tieviiva linestrings
+        for (var tv : visitor.tieviivat) {
+            var coords = transformer.transformLineString(tv.lineCoordinates());
+            for (var point : coords) {
+                assertValidFinlandCoordinate(point, "Tieviiva gid=" + tv.gid());
+            }
+        }
+
+        // Transform all Paikannimi points
+        for (var pn : visitor.paikannimet) {
+            var point = transformer.transformPoint(pn.pointEasting(), pn.pointNorthing());
+            assertValidFinlandCoordinate(point, "Paikannimi gid=" + pn.gid());
+        }
+    }
+
+    @Test
+    void coordinateTransform_sampleOsoitepiste_approximateLocation() throws Exception {
+        Assumptions.assumeTrue(Files.exists(SAMPLE_GML),
+                "Sample GML not found: " + SAMPLE_GML.toAbsolutePath());
+
+        var transformer = new CoordinateTransformer();
+        // Kuggö address point from sample data
+        var result = transformer.transformPoint(231221.828, 6677931.943);
+        // Should be in the Turku archipelago area: roughly lat ~60.1, lon ~22.2
+        assertEquals(60.1, result[0], 0.2, "Latitude should be near 60.1");
+        assertEquals(22.2, result[1], 0.2, "Longitude should be near 22.2");
+    }
+
+    @Test
+    void municipalityJson_sampleFile_spotCheckEntries() throws Exception {
+        Assumptions.assumeTrue(Files.exists(SAMPLE_JSON),
+                "Sample JSON not found: " + SAMPLE_JSON.toAbsolutePath());
+
+        try (var input = new FileInputStream(SAMPLE_JSON.toFile())) {
+            var entries = MunicipalityJsonParser.parse(input);
+
+            // Verify both municipalities from the GML sample area exist
+            var parainen = entries.stream().filter(e -> "445".equals(e.code())).findFirst().orElseThrow();
+            assertEquals("Parainen", parainen.nameFi());
+            assertEquals("Pargas", parainen.nameSv());
+
+            var kemionsaari = entries.stream().filter(e -> "322".equals(e.code())).findFirst().orElseThrow();
+            assertEquals("Kemiönsaari", kemionsaari.nameFi());
+            assertEquals("Kimitoön", kemionsaari.nameSv());
+
+            // All entries should have codes and at least a Finnish name
+            for (var entry : entries) {
+                assertNotNull(entry.code(), "Municipality code should not be null");
+                assertFalse(entry.code().isBlank(), "Municipality code should not be blank");
+            }
+        }
+    }
+
+    private static void assertValidFinlandCoordinate(double[] point, String context) {
+        assertTrue(point[0] >= 58.84 && point[0] <= 70.09,
+                context + ": latitude " + point[0] + " outside Finland bounds");
+        assertTrue(point[1] >= 19.08 && point[1] <= 31.59,
+                context + ": longitude " + point[1] + " outside Finland bounds");
+    }
+
+    private static class CollectingVisitor implements FeatureVisitor {
+        final List<KuntaFeature> kunnat = new ArrayList<>();
+        final List<TieviivaFeature> tieviivat = new ArrayList<>();
+        final List<OsoitepisteFeature> osoitepisteet = new ArrayList<>();
+        final List<PaikannimiFeature> paikannimet = new ArrayList<>();
+
+        @Override
+        public void onKunta(KuntaFeature feature) {
+            kunnat.add(feature);
+        }
+
+        @Override
+        public void onTieviiva(TieviivaFeature feature) {
+            tieviivat.add(feature);
+        }
+
+        @Override
+        public void onOsoitepiste(OsoitepisteFeature feature) {
+            osoitepisteet.add(feature);
+        }
+
+        @Override
+        public void onPaikannimi(PaikannimiFeature feature) {
+            paikannimet.add(feature);
+        }
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/MunicipalityJsonParserTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/parser/MunicipalityJsonParserTest.java
@@ -1,0 +1,159 @@
+package net.pkhapps.idispatchx.gis.importer.parser;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MunicipalityJsonParserTest {
+
+    private static final Path SAMPLE_DATA_FILE = Path.of("../../../SampleData/codelist_kunta_1_20250101.json");
+
+    @Test
+    void parse_validEntries_extractsCorrectly() throws IOException {
+        var json = """
+                {
+                  "codeValue": "kunta_1_20250101",
+                  "extensions": [],
+                  "codes": [
+                    {
+                      "codeValue": "445",
+                      "status": "VALID",
+                      "prefLabel": {
+                        "fi": "Parainen",
+                        "sv": "Pargas",
+                        "se": "Parainen",
+                        "smn": "Parainen",
+                        "sms": "Parainen",
+                        "en": "Pargas"
+                      }
+                    },
+                    {
+                      "codeValue": "322",
+                      "status": "VALID",
+                      "prefLabel": {
+                        "fi": "Kemiönsaari",
+                        "sv": "Kimitoön",
+                        "se": "Kemiönsaari",
+                        "smn": "Kemiönsaari",
+                        "sms": "Kemiönsaari",
+                        "en": "Kimitoön"
+                      }
+                    }
+                  ]
+                }
+                """;
+        var entries = MunicipalityJsonParser.parse(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(2, entries.size());
+
+        var parainen = entries.stream().filter(e -> "445".equals(e.code())).findFirst().orElseThrow();
+        assertEquals("Parainen", parainen.nameFi());
+        assertEquals("Pargas", parainen.nameSv());
+        assertEquals("Parainen", parainen.nameSme()); // "se" mapped to nameSme
+        assertEquals("Parainen", parainen.nameSmn());
+        assertEquals("Parainen", parainen.nameSms());
+    }
+
+    @Test
+    void parse_invalidStatusFiltered() throws IOException {
+        var json = """
+                {
+                  "codes": [
+                    {
+                      "codeValue": "999",
+                      "status": "DEPRECATED",
+                      "prefLabel": {"fi": "Old", "sv": "Old"}
+                    },
+                    {
+                      "codeValue": "100",
+                      "status": "VALID",
+                      "prefLabel": {"fi": "Valid", "sv": "Valid"}
+                    }
+                  ]
+                }
+                """;
+        var entries = MunicipalityJsonParser.parse(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(1, entries.size());
+        assertEquals("100", entries.getFirst().code());
+    }
+
+    @Test
+    void parse_languageMapping_seToSme() throws IOException {
+        var json = """
+                {
+                  "codes": [
+                    {
+                      "codeValue": "261",
+                      "status": "VALID",
+                      "prefLabel": {
+                        "fi": "Kittilä",
+                        "sv": "Kittilä",
+                        "se": "Gihttel",
+                        "smn": "Kittilä",
+                        "sms": "Kittilä"
+                      }
+                    }
+                  ]
+                }
+                """;
+        var entries = MunicipalityJsonParser.parse(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(1, entries.size());
+        assertEquals("Gihttel", entries.getFirst().nameSme());
+    }
+
+    @Test
+    void parse_extensionsIgnored() throws IOException {
+        var json = """
+                {
+                  "extensions": [
+                    {
+                      "propertyType": "cross-reference",
+                      "members": [{"code": "445", "relatedCode": "XYZ"}]
+                    }
+                  ],
+                  "codes": [
+                    {
+                      "codeValue": "445",
+                      "status": "VALID",
+                      "prefLabel": {"fi": "Parainen", "sv": "Pargas"}
+                    }
+                  ]
+                }
+                """;
+        var entries = MunicipalityJsonParser.parse(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(1, entries.size());
+    }
+
+    @Test
+    void parse_sampleDataFile_correctEntryCount() throws Exception {
+        Assumptions.assumeTrue(Files.exists(SAMPLE_DATA_FILE),
+                "Sample data file not found: " + SAMPLE_DATA_FILE.toAbsolutePath());
+
+        try (var input = new FileInputStream(SAMPLE_DATA_FILE.toFile())) {
+            var entries = MunicipalityJsonParser.parse(input);
+            // Should have valid municipalities — Finland has ~310 municipalities
+            assertTrue(entries.size() > 300, "Expected > 300 valid municipalities, got " + entries.size());
+            assertTrue(entries.size() < 350, "Expected < 350 valid municipalities, got " + entries.size());
+
+            // Spot check Parainen
+            var parainen = entries.stream().filter(e -> "445".equals(e.code())).findFirst().orElseThrow();
+            assertEquals("Parainen", parainen.nameFi());
+            assertEquals("Pargas", parainen.nameSv());
+        }
+    }
+}

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/transform/CoordinateTransformerTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/transform/CoordinateTransformerTest.java
@@ -25,6 +25,15 @@ class CoordinateTransformerTest {
     }
 
     @Test
+    void transformPoint_sampleDataCoordinate_approximateLocation() {
+        // From sample data: Kuggö address point
+        var result = transformer.transformPoint(231221.828, 6677931.943);
+        // Should be in the Turku archipelago area: roughly lat ~60.1, lon ~22.2
+        assertEquals(60.1, result[0], 0.2, "Latitude should be near 60.1");
+        assertEquals(22.2, result[1], 0.2, "Longitude should be near 22.2");
+    }
+
+    @Test
     void transformLineString_twoPoints_transformsBoth() {
         var coords = new double[][]{
                 {232056.555, 6678000.000},

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/transform/CoordinateTransformerTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/transform/CoordinateTransformerTest.java
@@ -1,0 +1,64 @@
+package net.pkhapps.idispatchx.gis.importer.transform;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CoordinateTransformerTest {
+
+    private final CoordinateTransformer transformer = new CoordinateTransformer();
+
+    @Test
+    void transformPoint_knownCoordinate_producesCorrectResult() {
+        // Helsinki area: EPSG:3067 (385000, 6672000) should be roughly lat ~60.17, lon ~24.94
+        var result = transformer.transformPoint(385000, 6672000);
+        assertEquals(60.17, result[0], 0.1);
+        assertEquals(24.94, result[1], 0.1);
+    }
+
+    @Test
+    void transformPoint_sampleDataCoordinate_withinFinlandBounds() {
+        // From sample data: Kuggö area in Parainen/Turku archipelago
+        var result = transformer.transformPoint(231221.828, 6677931.943);
+        assertTrue(result[0] >= 58.84 && result[0] <= 70.09, "Latitude should be within Finland bounds");
+        assertTrue(result[1] >= 19.08 && result[1] <= 31.59, "Longitude should be within Finland bounds");
+    }
+
+    @Test
+    void transformLineString_twoPoints_transformsBoth() {
+        var coords = new double[][]{
+                {232056.555, 6678000.000},
+                {232100.000, 6678050.000}
+        };
+        var result = transformer.transformLineString(coords);
+        assertEquals(2, result.length);
+        for (var point : result) {
+            assertEquals(2, point.length);
+            assertTrue(point[0] >= 58.84 && point[0] <= 70.09);
+            assertTrue(point[1] >= 19.08 && point[1] <= 31.59);
+        }
+    }
+
+    @Test
+    void transformPolygon_closedRing_transformsAll() {
+        var coords = new double[][]{
+                {234265.396, 6669060.097},
+                {231796.382, 6666000.000},
+                {232000.000, 6666000.000},
+                {234265.396, 6669060.097}
+        };
+        var result = transformer.transformPolygon(coords);
+        assertEquals(4, result.length);
+        for (var point : result) {
+            assertTrue(point[0] >= 58.84 && point[0] <= 70.09);
+            assertTrue(point[1] >= 19.08 && point[1] <= 31.59);
+        }
+    }
+
+    @Test
+    void transformPoint_outsideFinland_throws() {
+        // Coordinates way outside Finland (origin area)
+        assertThrows(IllegalArgumentException.class,
+                () -> transformer.transformPoint(0, 0));
+    }
+}


### PR DESCRIPTION
## Summary

- Implement the complete vector data import pipeline for the GIS Data Importer CLI tool, complementing the existing raster tile import
- Add coordinate transformation (EPSG:3067 → EPSG:4326), municipality JSON parsing, database connectivity, four feature importers with batched UPSERT/DELETE, a 3-pass import orchestrator, and full CLI integration
- Add 13 new tests (90 total) covering coordinate transformation, JSON parsing, and integration with sample data

## Test plan

- [x] All 90 unit/integration tests pass (`mvnw -pl tools/gis-data-importer test`)
- [x] Package builds successfully (`mvnw -pl tools/gis-data-importer -am package -DskipTests`)
- [x] Existing raster tile tests unaffected
- [x] End-to-end verification with PostGIS database (requires running database instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)