### PR TITLE
Implement GIS Server Phase 2: Authentication & Security

### DIFF
--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/AuthContext.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/AuthContext.java
@@ -1,0 +1,125 @@
+package net.pkhapps.idispatchx.gis.server.auth;
+
+import io.javalin.http.Context;
+import net.pkhapps.idispatchx.common.auth.Role;
+import net.pkhapps.idispatchx.common.auth.TokenClaims;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Utility class for accessing authentication context from Javalin request context.
+ * <p>
+ * This class provides static methods to:
+ * <ul>
+ *   <li>Store validated token claims in the context</li>
+ *   <li>Retrieve token claims from the context</li>
+ *   <li>Check user roles and permissions</li>
+ * </ul>
+ */
+public final class AuthContext {
+
+    /**
+     * Context attribute key for storing token claims.
+     */
+    static final String CLAIMS_ATTRIBUTE = "auth.tokenClaims";
+
+    private AuthContext() {
+        // Utility class
+    }
+
+    /**
+     * Stores validated token claims in the request context.
+     *
+     * @param ctx    the Javalin context
+     * @param claims the validated token claims
+     */
+    public static void setClaims(Context ctx, TokenClaims claims) {
+        Objects.requireNonNull(ctx, "ctx must not be null");
+        Objects.requireNonNull(claims, "claims must not be null");
+        ctx.attribute(CLAIMS_ATTRIBUTE, claims);
+    }
+
+    /**
+     * Retrieves the token claims from the request context.
+     *
+     * @param ctx the Javalin context
+     * @return the token claims, or null if not authenticated
+     */
+    public static @Nullable TokenClaims getClaims(Context ctx) {
+        Objects.requireNonNull(ctx, "ctx must not be null");
+        return ctx.attribute(CLAIMS_ATTRIBUTE);
+    }
+
+    /**
+     * Retrieves the token claims, throwing if not authenticated.
+     *
+     * @param ctx the Javalin context
+     * @return the token claims
+     * @throws IllegalStateException if the request is not authenticated
+     */
+    public static TokenClaims requireClaims(Context ctx) {
+        var claims = getClaims(ctx);
+        if (claims == null) {
+            throw new IllegalStateException("Request is not authenticated");
+        }
+        return claims;
+    }
+
+    /**
+     * Returns the authenticated user's subject (user ID).
+     *
+     * @param ctx the Javalin context
+     * @return the subject, or null if not authenticated
+     */
+    public static @Nullable String getSubject(Context ctx) {
+        var claims = getClaims(ctx);
+        return claims != null ? claims.subject() : null;
+    }
+
+    /**
+     * Returns the authenticated user's roles.
+     *
+     * @param ctx the Javalin context
+     * @return the user's roles, or empty set if not authenticated
+     */
+    public static Set<Role> getRoles(Context ctx) {
+        var claims = getClaims(ctx);
+        return claims != null ? claims.roles() : Set.of();
+    }
+
+    /**
+     * Checks if the authenticated user has the specified role.
+     *
+     * @param ctx  the Javalin context
+     * @param role the role to check
+     * @return true if the user has the role
+     */
+    public static boolean hasRole(Context ctx, Role role) {
+        var claims = getClaims(ctx);
+        return claims != null && claims.hasRole(role);
+    }
+
+    /**
+     * Checks if the authenticated user has any of the specified roles.
+     *
+     * @param ctx   the Javalin context
+     * @param roles the roles to check
+     * @return true if the user has at least one of the roles
+     */
+    public static boolean hasAnyRole(Context ctx, Role... roles) {
+        var claims = getClaims(ctx);
+        return claims != null && claims.hasAnyRole(roles);
+    }
+
+    /**
+     * Checks if the request is authenticated.
+     *
+     * @param ctx the Javalin context
+     * @return true if the request has valid authentication
+     */
+    public static boolean isAuthenticated(Context ctx) {
+        return getClaims(ctx) != null;
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/BackChannelLogoutHandler.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/BackChannelLogoutHandler.java
@@ -1,0 +1,101 @@
+package net.pkhapps.idispatchx.gis.server.auth;
+
+import io.javalin.http.BadRequestResponse;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.http.HttpStatus;
+import net.pkhapps.idispatchx.common.auth.JwksException;
+import net.pkhapps.idispatchx.common.auth.LogoutTokenValidator;
+import net.pkhapps.idispatchx.common.auth.SessionStore;
+import net.pkhapps.idispatchx.common.auth.TokenValidationException;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/**
+ * Javalin handler for OIDC Back-Channel Logout notifications.
+ * <p>
+ * This handler receives logout tokens from the OIDC provider when a user
+ * logs out. It validates the token and records the session revocation
+ * in the session store.
+ * <p>
+ * Per the OIDC specification, this endpoint:
+ * <ul>
+ *   <li>Accepts POST requests with application/x-www-form-urlencoded body</li>
+ *   <li>Expects a 'logout_token' form parameter</li>
+ *   <li>Returns 200 OK on success</li>
+ *   <li>Returns 400 Bad Request on validation failure</li>
+ * </ul>
+ * <p>
+ * Usage:
+ * <pre>
+ * app.post("/logout/backchannel", new BackChannelLogoutHandler(logoutValidator, sessionStore));
+ * </pre>
+ *
+ * @see <a href="https://openid.net/specs/openid-connect-backchannel-1_0.html">
+ *     OpenID Connect Back-Channel Logout 1.0</a>
+ */
+public final class BackChannelLogoutHandler implements Handler {
+
+    private static final Logger log = LoggerFactory.getLogger(BackChannelLogoutHandler.class);
+
+    private static final String LOGOUT_TOKEN_PARAM = "logout_token";
+
+    private final LogoutTokenValidator logoutTokenValidator;
+    private final SessionStore sessionStore;
+
+    /**
+     * Creates a new back-channel logout handler.
+     *
+     * @param logoutTokenValidator the validator for logout tokens
+     * @param sessionStore         the session store for recording revocations
+     */
+    public BackChannelLogoutHandler(LogoutTokenValidator logoutTokenValidator,
+                                    SessionStore sessionStore) {
+        this.logoutTokenValidator = Objects.requireNonNull(logoutTokenValidator,
+                "logoutTokenValidator must not be null");
+        this.sessionStore = Objects.requireNonNull(sessionStore,
+                "sessionStore must not be null");
+    }
+
+    @Override
+    public void handle(@NotNull Context ctx) throws Exception {
+        var logoutToken = ctx.formParam(LOGOUT_TOKEN_PARAM);
+
+        if (logoutToken == null || logoutToken.isBlank()) {
+            log.debug("Back-channel logout request missing logout_token");
+            throw new BadRequestResponse("Missing logout_token parameter");
+        }
+
+        try {
+            var claims = logoutTokenValidator.validate(logoutToken);
+
+            if (claims.hasSessionId()) {
+                // Revoke specific session
+                sessionStore.revokeSession(claims.sessionId());
+                log.info("Revoked session: {} for subject: {}",
+                        claims.sessionId(), claims.subject());
+            } else if (claims.isSubjectLogout()) {
+                // Subject-only logout - this implementation only supports session-based logout
+                // For full subject logout, you would need to track all sessions per subject
+                log.warn("Received subject-only logout for {} - session tracking required",
+                        claims.subject());
+            }
+
+            ctx.status(HttpStatus.OK);
+            ctx.result("");
+
+        } catch (TokenValidationException e) {
+            log.debug("Back-channel logout token validation failed: {} - {}",
+                    e.getErrorCode(), e.getMessage());
+            throw new BadRequestResponse("Invalid logout token: " + e.getMessage());
+
+        } catch (JwksException e) {
+            log.warn("JWKS error during logout token validation: {}", e.getMessage());
+            ctx.status(HttpStatus.SERVICE_UNAVAILABLE);
+            ctx.result("Service unavailable");
+        }
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/BackChannelLogoutHandler.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/BackChannelLogoutHandler.java
@@ -8,7 +8,6 @@ import net.pkhapps.idispatchx.common.auth.JwksException;
 import net.pkhapps.idispatchx.common.auth.LogoutTokenValidator;
 import net.pkhapps.idispatchx.common.auth.SessionStore;
 import net.pkhapps.idispatchx.common.auth.TokenValidationException;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +60,7 @@ public final class BackChannelLogoutHandler implements Handler {
     }
 
     @Override
-    public void handle(@NotNull Context ctx) throws Exception {
+    public void handle(Context ctx) throws Exception {
         var logoutToken = ctx.formParam(LOGOUT_TOKEN_PARAM);
 
         if (logoutToken == null || logoutToken.isBlank()) {

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/JwtAuthHandler.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/JwtAuthHandler.java
@@ -8,7 +8,6 @@ import net.pkhapps.idispatchx.common.auth.JwksException;
 import net.pkhapps.idispatchx.common.auth.SessionStore;
 import net.pkhapps.idispatchx.common.auth.TokenValidationException;
 import net.pkhapps.idispatchx.common.auth.TokenValidator;
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +59,7 @@ public final class JwtAuthHandler implements Handler {
     }
 
     @Override
-    public void handle(@NotNull Context ctx) throws Exception {
+    public void handle(Context ctx) throws Exception {
         var authHeader = ctx.header(AUTHORIZATION_HEADER);
 
         if (authHeader == null || authHeader.isBlank()) {

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/JwtAuthHandler.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/JwtAuthHandler.java
@@ -1,0 +1,94 @@
+package net.pkhapps.idispatchx.gis.server.auth;
+
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import io.javalin.http.HttpStatus;
+import io.javalin.http.UnauthorizedResponse;
+import net.pkhapps.idispatchx.common.auth.JwksException;
+import net.pkhapps.idispatchx.common.auth.TokenValidationException;
+import net.pkhapps.idispatchx.common.auth.TokenValidator;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/**
+ * Javalin handler that validates JWT tokens from the Authorization header.
+ * <p>
+ * This handler extracts Bearer tokens from the Authorization header,
+ * validates them using the provided {@link TokenValidator}, and stores
+ * the validated claims in the request context via {@link AuthContext}.
+ * <p>
+ * If validation fails, the handler responds with HTTP 401 Unauthorized.
+ * <p>
+ * Usage:
+ * <pre>
+ * app.before("/api/*", new JwtAuthHandler(tokenValidator));
+ * </pre>
+ */
+public final class JwtAuthHandler implements Handler {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthHandler.class);
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private final TokenValidator tokenValidator;
+
+    /**
+     * Creates a new JWT authentication handler.
+     *
+     * @param tokenValidator the token validator for validating JWTs
+     */
+    public JwtAuthHandler(TokenValidator tokenValidator) {
+        this.tokenValidator = Objects.requireNonNull(tokenValidator, "tokenValidator must not be null");
+    }
+
+    @Override
+    public void handle(@NotNull Context ctx) throws Exception {
+        var authHeader = ctx.header(AUTHORIZATION_HEADER);
+
+        if (authHeader == null || authHeader.isBlank()) {
+            log.debug("Missing Authorization header for {}", ctx.path());
+            throw new UnauthorizedResponse("Missing Authorization header");
+        }
+
+        if (!authHeader.startsWith(BEARER_PREFIX)) {
+            log.debug("Invalid Authorization header format for {}", ctx.path());
+            throw new UnauthorizedResponse("Invalid Authorization header format");
+        }
+
+        var token = authHeader.substring(BEARER_PREFIX.length()).trim();
+
+        if (token.isEmpty()) {
+            log.debug("Empty token in Authorization header for {}", ctx.path());
+            throw new UnauthorizedResponse("Missing token");
+        }
+
+        try {
+            var claims = tokenValidator.validate(token);
+            AuthContext.setClaims(ctx, claims);
+            log.debug("Authenticated request for subject: {}", claims.subject());
+        } catch (TokenValidationException e) {
+            log.debug("Token validation failed for {}: {} - {}",
+                    ctx.path(), e.getErrorCode(), e.getMessage());
+            handleValidationError(e);
+        } catch (JwksException e) {
+            log.warn("JWKS error during token validation: {}", e.getMessage());
+            ctx.status(HttpStatus.SERVICE_UNAVAILABLE);
+            ctx.result("Authentication service unavailable");
+        }
+    }
+
+    private void handleValidationError(TokenValidationException e) {
+        var message = switch (e.getErrorCode()) {
+            case TOKEN_EXPIRED -> "Token expired";
+            case INVALID_SIGNATURE -> "Invalid token signature";
+            case INVALID_ISSUER -> "Invalid token issuer";
+            case KEY_NOT_FOUND -> "Token signing key not found";
+            case MISSING_CLAIM, INVALID_TOKEN -> "Invalid token";
+        };
+        throw new UnauthorizedResponse(message);
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/RoleAuthHandler.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/RoleAuthHandler.java
@@ -5,11 +5,9 @@ import io.javalin.http.ForbiddenResponse;
 import io.javalin.http.Handler;
 import io.javalin.http.UnauthorizedResponse;
 import net.pkhapps.idispatchx.common.auth.Role;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
 
@@ -68,14 +66,14 @@ public final class RoleAuthHandler implements Handler {
      * @return the role authorization handler
      */
     public static RoleAuthHandler requireAnyRole(Role... roles) {
-        if (roles == null || roles.length == 0) {
+        if (roles.length == 0) {
             throw new IllegalArgumentException("At least one role must be specified");
         }
         return new RoleAuthHandler(Set.of(roles));
     }
 
     @Override
-    public void handle(@NotNull Context ctx) throws Exception {
+    public void handle(Context ctx) throws Exception {
         var claims = AuthContext.getClaims(ctx);
 
         if (claims == null) {

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/RoleAuthHandler.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/RoleAuthHandler.java
@@ -1,0 +1,107 @@
+package net.pkhapps.idispatchx.gis.server.auth;
+
+import io.javalin.http.Context;
+import io.javalin.http.ForbiddenResponse;
+import io.javalin.http.Handler;
+import io.javalin.http.UnauthorizedResponse;
+import net.pkhapps.idispatchx.common.auth.Role;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Javalin handler that enforces role-based access control.
+ * <p>
+ * This handler checks if the authenticated user has at least one of the
+ * required roles. It must be used after {@link JwtAuthHandler} in the
+ * handler chain.
+ * <p>
+ * If the user is not authenticated, responds with HTTP 401 Unauthorized.
+ * If the user lacks required roles, responds with HTTP 403 Forbidden.
+ * <p>
+ * Usage:
+ * <pre>
+ * // Require Dispatcher role
+ * app.get("/api/dispatch/*", ctx -> {...}, RoleAuthHandler.requireRole(Role.DISPATCHER));
+ *
+ * // Require any of multiple roles
+ * app.get("/api/data/*", ctx -> {...}, RoleAuthHandler.requireAnyRole(Role.DISPATCHER, Role.OBSERVER));
+ * </pre>
+ */
+public final class RoleAuthHandler implements Handler {
+
+    private static final Logger log = LoggerFactory.getLogger(RoleAuthHandler.class);
+
+    private final Set<Role> requiredRoles;
+
+    /**
+     * Creates a new role authorization handler.
+     *
+     * @param requiredRoles the roles that grant access (at least one required)
+     */
+    private RoleAuthHandler(Set<Role> requiredRoles) {
+        if (requiredRoles.isEmpty()) {
+            throw new IllegalArgumentException("At least one role must be required");
+        }
+        this.requiredRoles = Set.copyOf(requiredRoles);
+    }
+
+    /**
+     * Creates a handler that requires a specific role.
+     *
+     * @param role the required role
+     * @return the role authorization handler
+     */
+    public static RoleAuthHandler requireRole(Role role) {
+        Objects.requireNonNull(role, "role must not be null");
+        return new RoleAuthHandler(Set.of(role));
+    }
+
+    /**
+     * Creates a handler that requires any of the specified roles.
+     *
+     * @param roles the roles that grant access (at least one required)
+     * @return the role authorization handler
+     */
+    public static RoleAuthHandler requireAnyRole(Role... roles) {
+        if (roles == null || roles.length == 0) {
+            throw new IllegalArgumentException("At least one role must be specified");
+        }
+        return new RoleAuthHandler(Set.of(roles));
+    }
+
+    @Override
+    public void handle(@NotNull Context ctx) throws Exception {
+        var claims = AuthContext.getClaims(ctx);
+
+        if (claims == null) {
+            log.debug("Unauthenticated request attempted to access {}", ctx.path());
+            throw new UnauthorizedResponse("Authentication required");
+        }
+
+        boolean hasRole = claims.roles().stream()
+                .anyMatch(requiredRoles::contains);
+
+        if (!hasRole) {
+            log.debug("User {} lacks required roles {} for {}",
+                    claims.subject(), requiredRoles, ctx.path());
+            throw new ForbiddenResponse("Insufficient permissions");
+        }
+
+        log.debug("User {} authorized for {} with roles {}",
+                claims.subject(), ctx.path(), claims.roles());
+    }
+
+    /**
+     * Returns the roles that grant access to this handler.
+     *
+     * @return the required roles
+     */
+    public Set<Role> getRequiredRoles() {
+        return requiredRoles;
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/package-info.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/auth/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Authentication and authorization handlers for the GIS Server.
+ * <p>
+ * This package provides Javalin handlers for:
+ * <ul>
+ *   <li>JWT token validation ({@link net.pkhapps.idispatchx.gis.server.auth.JwtAuthHandler})</li>
+ *   <li>Role-based authorization ({@link net.pkhapps.idispatchx.gis.server.auth.RoleAuthHandler})</li>
+ *   <li>Authentication context access ({@link net.pkhapps.idispatchx.gis.server.auth.AuthContext})</li>
+ * </ul>
+ */
+@NullMarked
+package net.pkhapps.idispatchx.gis.server.auth;
+
+import org.jspecify.annotations.NullMarked;

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/MainTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/MainTest.java
@@ -3,7 +3,6 @@ package net.pkhapps.idispatchx.gis.server;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;

--- a/Implementation/shared/java-common/pom.xml
+++ b/Implementation/shared/java-common/pom.xml
@@ -32,5 +32,9 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/JwksClient.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/JwksClient.java
@@ -1,0 +1,202 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.text.ParseException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Client for fetching and caching JSON Web Key Sets (JWKS) from an OIDC provider.
+ * <p>
+ * The client caches the JWKS for a configurable time-to-live (TTL) and automatically
+ * refreshes when a key is not found, supporting key rotation scenarios.
+ * <p>
+ * This class is thread-safe.
+ */
+public final class JwksClient implements JwksKeyProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(JwksClient.class);
+
+    /**
+     * Default cache TTL of 5 minutes.
+     */
+    public static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(5);
+
+    /**
+     * Default HTTP request timeout.
+     */
+    public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
+
+    private final URI jwksUri;
+    private final Duration cacheTtl;
+    private final HttpClient httpClient;
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private @Nullable JWKSet cachedJwkSet;
+    private @Nullable Instant cacheExpiry;
+
+    /**
+     * Creates a new JWKS client with default settings.
+     *
+     * @param jwksUri the JWKS endpoint URI
+     */
+    public JwksClient(URI jwksUri) {
+        this(jwksUri, DEFAULT_CACHE_TTL, createDefaultHttpClient());
+    }
+
+    /**
+     * Creates a new JWKS client with custom settings.
+     *
+     * @param jwksUri    the JWKS endpoint URI
+     * @param cacheTtl   the cache time-to-live
+     * @param httpClient the HTTP client to use
+     */
+    public JwksClient(URI jwksUri, Duration cacheTtl, HttpClient httpClient) {
+        this.jwksUri = Objects.requireNonNull(jwksUri, "jwksUri must not be null");
+        this.cacheTtl = Objects.requireNonNull(cacheTtl, "cacheTtl must not be null");
+        this.httpClient = Objects.requireNonNull(httpClient, "httpClient must not be null");
+
+        if (cacheTtl.isNegative() || cacheTtl.isZero()) {
+            throw new IllegalArgumentException("cacheTtl must be positive");
+        }
+
+        log.info("JWKS client initialized for {}", jwksUri);
+    }
+
+    private static HttpClient createDefaultHttpClient() {
+        return HttpClient.newBuilder()
+                .connectTimeout(DEFAULT_TIMEOUT)
+                .build();
+    }
+
+    /**
+     * Gets a JWK by its key ID.
+     * <p>
+     * If the key is not found in the cache, the JWKS is refreshed from the server
+     * to support key rotation scenarios.
+     *
+     * @param keyId the key ID (kid)
+     * @return the JWK, or null if not found
+     * @throws JwksException if fetching the JWKS fails
+     */
+    public @Nullable JWK getKey(String keyId) {
+        Objects.requireNonNull(keyId, "keyId must not be null");
+
+        // Try to get from cache first
+        var jwkSet = getCachedJwkSet();
+        if (jwkSet != null) {
+            var key = jwkSet.getKeyByKeyId(keyId);
+            if (key != null) {
+                return key;
+            }
+            // Key not found, refresh to handle key rotation
+            log.debug("Key {} not found in cache, refreshing JWKS", keyId);
+        }
+
+        // Refresh and try again
+        jwkSet = refreshJwkSet();
+        return jwkSet.getKeyByKeyId(keyId);
+    }
+
+    /**
+     * Gets the cached JWKS if valid, or null if expired/not cached.
+     */
+    private @Nullable JWKSet getCachedJwkSet() {
+        lock.readLock().lock();
+        try {
+            if (cachedJwkSet != null && cacheExpiry != null && Instant.now().isBefore(cacheExpiry)) {
+                return cachedJwkSet;
+            }
+            return null;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Refreshes the JWKS from the server.
+     */
+    private JWKSet refreshJwkSet() {
+        lock.writeLock().lock();
+        try {
+            // Double-check in case another thread already refreshed
+            if (cachedJwkSet != null && cacheExpiry != null && Instant.now().isBefore(cacheExpiry)) {
+                return cachedJwkSet;
+            }
+
+            log.debug("Fetching JWKS from {}", jwksUri);
+            var jwkSet = fetchJwkSet();
+            cachedJwkSet = jwkSet;
+            cacheExpiry = Instant.now().plus(cacheTtl);
+            log.debug("JWKS cached with {} keys, expires at {}", jwkSet.getKeys().size(), cacheExpiry);
+            return jwkSet;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Fetches the JWKS from the server.
+     */
+    private JWKSet fetchJwkSet() {
+        try {
+            var request = HttpRequest.newBuilder()
+                    .uri(jwksUri)
+                    .timeout(DEFAULT_TIMEOUT)
+                    .GET()
+                    .build();
+
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new JwksException("JWKS endpoint returned status " + response.statusCode());
+            }
+
+            return JWKSet.parse(response.body());
+        } catch (IOException e) {
+            throw new JwksException("Failed to fetch JWKS from " + jwksUri + ": " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new JwksException("JWKS fetch interrupted", e);
+        } catch (ParseException e) {
+            throw new JwksException("Failed to parse JWKS: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Forces a refresh of the cached JWKS.
+     *
+     * @throws JwksException if fetching the JWKS fails
+     */
+    public void refresh() {
+        lock.writeLock().lock();
+        try {
+            cachedJwkSet = null;
+            cacheExpiry = null;
+        } finally {
+            lock.writeLock().unlock();
+        }
+        refreshJwkSet();
+    }
+
+    /**
+     * Returns the JWKS endpoint URI.
+     *
+     * @return the JWKS URI
+     */
+    public URI getJwksUri() {
+        return jwksUri;
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/JwksException.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/JwksException.java
@@ -1,0 +1,26 @@
+package net.pkhapps.idispatchx.common.auth;
+
+/**
+ * Exception thrown when JWKS operations fail.
+ */
+public class JwksException extends RuntimeException {
+
+    /**
+     * Creates a new JWKS exception with the given message.
+     *
+     * @param message the error message
+     */
+    public JwksException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new JWKS exception with the given message and cause.
+     *
+     * @param message the error message
+     * @param cause   the underlying cause
+     */
+    public JwksException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/JwksKeyProvider.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/JwksKeyProvider.java
@@ -1,0 +1,21 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import com.nimbusds.jose.jwk.JWK;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Provider for JSON Web Keys (JWK) used for JWT signature verification.
+ * <p>
+ * Implementations fetch and cache keys from a JWKS endpoint or other source.
+ */
+public interface JwksKeyProvider {
+
+    /**
+     * Gets a JWK by its key ID.
+     *
+     * @param keyId the key ID (kid)
+     * @return the JWK, or null if not found
+     * @throws JwksException if fetching the key fails
+     */
+    @Nullable JWK getKey(String keyId);
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/LogoutTokenValidator.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/LogoutTokenValidator.java
@@ -1,0 +1,285 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.jspecify.annotations.Nullable;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Validates OIDC Back-Channel Logout tokens.
+ * <p>
+ * Logout tokens are JWTs sent by the OIDC provider when a user logs out.
+ * They contain a 'sid' (session ID) and/or 'sub' (subject) claim to identify
+ * which sessions should be terminated.
+ * <p>
+ * Per the OIDC Back-Channel Logout specification, a valid logout token must:
+ * <ul>
+ *   <li>Be signed by the OIDC provider's key</li>
+ *   <li>Contain the expected issuer</li>
+ *   <li>Contain the expected audience (client ID)</li>
+ *   <li>Not be expired (within reasonable clock skew)</li>
+ *   <li>Contain an 'events' claim with the logout event type</li>
+ *   <li>Contain either 'sid' or 'sub' claim (or both)</li>
+ *   <li>NOT contain a 'nonce' claim</li>
+ * </ul>
+ *
+ * @see <a href="https://openid.net/specs/openid-connect-backchannel-1_0.html">
+ *     OpenID Connect Back-Channel Logout 1.0</a>
+ */
+public final class LogoutTokenValidator {
+
+    /**
+     * The OIDC back-channel logout event type.
+     */
+    public static final String LOGOUT_EVENT_TYPE =
+            "http://schemas.openid.net/event/backchannel-logout";
+
+    private final JwksKeyProvider keyProvider;
+    private final String expectedIssuer;
+    private final String expectedAudience;
+
+    /**
+     * Creates a new logout token validator.
+     *
+     * @param keyProvider      the key provider for fetching signing keys
+     * @param expectedIssuer   the expected token issuer (must match access tokens)
+     * @param expectedAudience the expected audience (client ID)
+     */
+    public LogoutTokenValidator(JwksKeyProvider keyProvider, String expectedIssuer,
+                                String expectedAudience) {
+        this.keyProvider = Objects.requireNonNull(keyProvider, "keyProvider must not be null");
+        this.expectedIssuer = Objects.requireNonNull(expectedIssuer, "expectedIssuer must not be null");
+        this.expectedAudience = Objects.requireNonNull(expectedAudience, "expectedAudience must not be null");
+
+        if (expectedIssuer.isBlank()) {
+            throw new IllegalArgumentException("expectedIssuer must not be blank");
+        }
+        if (expectedAudience.isBlank()) {
+            throw new IllegalArgumentException("expectedAudience must not be blank");
+        }
+    }
+
+    /**
+     * Validates a logout token and extracts session information.
+     *
+     * @param token the logout token string
+     * @return the validated logout claims
+     * @throws TokenValidationException if validation fails
+     */
+    public LogoutClaims validate(String token) {
+        Objects.requireNonNull(token, "token must not be null");
+
+        // Parse the token
+        SignedJWT signedJWT;
+        try {
+            signedJWT = SignedJWT.parse(token);
+        } catch (ParseException e) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Failed to parse logout token: " + e.getMessage(), e);
+        }
+
+        // Get the key ID from the token header
+        var keyId = signedJWT.getHeader().getKeyID();
+        if (keyId == null) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Logout token does not contain a key ID (kid)");
+        }
+
+        // Fetch the signing key
+        var jwk = keyProvider.getKey(keyId);
+        if (jwk == null) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.KEY_NOT_FOUND,
+                    "Signing key not found: " + keyId);
+        }
+
+        // Verify the signature
+        verifySignature(signedJWT, jwk);
+
+        // Extract and validate claims
+        JWTClaimsSet claims;
+        try {
+            claims = signedJWT.getJWTClaimsSet();
+        } catch (ParseException e) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Failed to extract claims: " + e.getMessage(), e);
+        }
+
+        return validateClaims(claims);
+    }
+
+    private void verifySignature(SignedJWT signedJWT, JWK jwk) {
+        try {
+            JWSVerifier verifier = createVerifier(jwk);
+            if (!signedJWT.verify(verifier)) {
+                throw new TokenValidationException(
+                        TokenValidationException.ErrorCode.INVALID_SIGNATURE,
+                        "Logout token signature verification failed");
+            }
+        } catch (JOSEException e) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_SIGNATURE,
+                    "Signature verification error: " + e.getMessage(), e);
+        }
+    }
+
+    private JWSVerifier createVerifier(JWK jwk) throws JOSEException {
+        if (jwk instanceof RSAKey rsaKey) {
+            return new RSASSAVerifier(rsaKey.toRSAPublicKey());
+        } else if (jwk instanceof ECKey ecKey) {
+            return new ECDSAVerifier(ecKey.toECPublicKey());
+        } else {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Unsupported key type: " + jwk.getKeyType());
+        }
+    }
+
+    private LogoutClaims validateClaims(JWTClaimsSet claims) {
+        // Validate issuer
+        var issuer = claims.getIssuer();
+        if (issuer == null) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.MISSING_CLAIM,
+                    "Logout token does not contain issuer (iss) claim");
+        }
+        if (!expectedIssuer.equals(issuer)) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_ISSUER,
+                    "Logout token issuer '" + issuer + "' does not match expected '" + expectedIssuer + "'");
+        }
+
+        // Validate audience
+        var audience = claims.getAudience();
+        if (audience == null || audience.isEmpty()) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.MISSING_CLAIM,
+                    "Logout token does not contain audience (aud) claim");
+        }
+        if (!audience.contains(expectedAudience)) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Logout token audience does not include expected client");
+        }
+
+        // Validate expiration (with 60 second clock skew tolerance)
+        var expirationTime = claims.getExpirationTime();
+        if (expirationTime != null) {
+            var now = new Date();
+            var skewAllowance = 60_000L; // 60 seconds
+            if (expirationTime.getTime() + skewAllowance < now.getTime()) {
+                throw new TokenValidationException(
+                        TokenValidationException.ErrorCode.TOKEN_EXPIRED,
+                        "Logout token has expired");
+            }
+        }
+
+        // Validate events claim
+        validateEventsClaimPresent(claims);
+
+        // Validate nonce is NOT present (per spec)
+        try {
+            if (claims.getStringClaim("nonce") != null) {
+                throw new TokenValidationException(
+                        TokenValidationException.ErrorCode.INVALID_TOKEN,
+                        "Logout token must not contain nonce claim");
+            }
+        } catch (ParseException e) {
+            // Ignore parse errors for nonce
+        }
+
+        // Extract session ID and subject
+        var sessionId = getStringClaim(claims, "sid");
+        var subject = claims.getSubject();
+
+        // At least one of sid or sub must be present
+        if (sessionId == null && subject == null) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.MISSING_CLAIM,
+                    "Logout token must contain either sid or sub claim");
+        }
+
+        return new LogoutClaims(sessionId, subject);
+    }
+
+    private void validateEventsClaimPresent(JWTClaimsSet claims) {
+        try {
+            var events = claims.getClaim("events");
+            if (events == null) {
+                throw new TokenValidationException(
+                        TokenValidationException.ErrorCode.MISSING_CLAIM,
+                        "Logout token does not contain events claim");
+            }
+
+            // Events should be a JSON object with the logout event type as a key
+            if (events instanceof Map<?, ?> eventsMap) {
+                if (!eventsMap.containsKey(LOGOUT_EVENT_TYPE)) {
+                    throw new TokenValidationException(
+                            TokenValidationException.ErrorCode.INVALID_TOKEN,
+                            "Logout token events claim does not contain logout event type");
+                }
+            } else {
+                throw new TokenValidationException(
+                        TokenValidationException.ErrorCode.INVALID_TOKEN,
+                        "Logout token events claim has invalid format");
+            }
+        } catch (TokenValidationException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Failed to parse events claim: " + e.getMessage(), e);
+        }
+    }
+
+    private @Nullable String getStringClaim(JWTClaimsSet claims, String claimName) {
+        try {
+            return claims.getStringClaim(claimName);
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Claims extracted from a validated logout token.
+     *
+     * @param sessionId the session ID to revoke, or null if not provided
+     * @param subject   the subject (user ID) whose sessions to revoke, or null if not provided
+     */
+    public record LogoutClaims(
+            @Nullable String sessionId,
+            @Nullable String subject
+    ) {
+        /**
+         * Returns whether this logout applies to a specific session.
+         *
+         * @return true if a session ID is present
+         */
+        public boolean hasSessionId() {
+            return sessionId != null;
+        }
+
+        /**
+         * Returns whether this logout applies to all sessions for a subject.
+         *
+         * @return true if only subject is present (no session ID)
+         */
+        public boolean isSubjectLogout() {
+            return sessionId == null && subject != null;
+        }
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/Role.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/Role.java
@@ -1,0 +1,64 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * System roles for iDispatchX users.
+ * <p>
+ * Roles are assigned to users via the OIDC provider and included in JWT tokens.
+ */
+public enum Role {
+
+    /**
+     * Dispatcher role - full access to CAD and GIS functionality.
+     */
+    DISPATCHER("Dispatcher"),
+
+    /**
+     * Observer role - read-only access to CAD and GIS functionality.
+     */
+    OBSERVER("Observer"),
+
+    /**
+     * Admin role - access to administrative functions.
+     */
+    ADMIN("Admin"),
+
+    /**
+     * Station role - access to station alert functionality.
+     */
+    STATION("Station"),
+
+    /**
+     * Unit role - access to mobile unit functionality.
+     */
+    UNIT("Unit");
+
+    private final String claimValue;
+
+    Role(String claimValue) {
+        this.claimValue = claimValue;
+    }
+
+    /**
+     * Returns the role claim value as it appears in JWT tokens.
+     *
+     * @return the claim value
+     */
+    public String getClaimValue() {
+        return claimValue;
+    }
+
+    /**
+     * Finds a role by its claim value.
+     *
+     * @param claimValue the claim value to search for
+     * @return the matching role, or empty if not found
+     */
+    public static Optional<Role> fromClaimValue(String claimValue) {
+        return Arrays.stream(values())
+                .filter(role -> role.claimValue.equalsIgnoreCase(claimValue))
+                .findFirst();
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/SessionStore.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/SessionStore.java
@@ -1,0 +1,191 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * In-memory store for tracking revoked sessions.
+ * <p>
+ * When a back-channel logout notification is received, the session ID
+ * is added to this store. Subsequent token validation should check
+ * this store to determine if a session has been revoked.
+ * <p>
+ * Revoked sessions are automatically removed after a configurable TTL
+ * to prevent unbounded memory growth. The TTL should be at least as long
+ * as the maximum token lifetime.
+ * <p>
+ * This implementation is thread-safe but does not persist across restarts.
+ * For production deployments with multiple server instances, consider using
+ * a distributed cache like Redis.
+ */
+public final class SessionStore implements AutoCloseable {
+
+    /**
+     * Default session revocation TTL of 1 hour.
+     * <p>
+     * This should be longer than the maximum access token lifetime to ensure
+     * revoked tokens are rejected until they expire naturally.
+     */
+    public static final Duration DEFAULT_REVOCATION_TTL = Duration.ofHours(1);
+
+    private static final Duration CLEANUP_INTERVAL = Duration.ofMinutes(5);
+
+    private final ConcurrentMap<String, Instant> revokedSessions = new ConcurrentHashMap<>();
+    private final Duration revocationTtl;
+    private final @Nullable ScheduledExecutorService cleanupExecutor;
+
+    /**
+     * Creates a new session store with the default revocation TTL.
+     */
+    public SessionStore() {
+        this(DEFAULT_REVOCATION_TTL);
+    }
+
+    /**
+     * Creates a new session store with a custom revocation TTL.
+     *
+     * @param revocationTtl how long to keep revoked sessions in the store
+     */
+    public SessionStore(Duration revocationTtl) {
+        this(revocationTtl, true);
+    }
+
+    /**
+     * Creates a new session store with optional cleanup scheduling.
+     *
+     * @param revocationTtl   how long to keep revoked sessions in the store
+     * @param scheduleCleanup whether to schedule periodic cleanup (false for testing)
+     */
+    SessionStore(Duration revocationTtl, boolean scheduleCleanup) {
+        this.revocationTtl = Objects.requireNonNull(revocationTtl, "revocationTtl must not be null");
+
+        if (revocationTtl.isNegative() || revocationTtl.isZero()) {
+            throw new IllegalArgumentException("revocationTtl must be positive");
+        }
+
+        if (scheduleCleanup) {
+            this.cleanupExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+                var thread = new Thread(r, "session-store-cleanup");
+                thread.setDaemon(true);
+                return thread;
+            });
+            cleanupExecutor.scheduleAtFixedRate(
+                    this::cleanupExpired,
+                    CLEANUP_INTERVAL.toSeconds(),
+                    CLEANUP_INTERVAL.toSeconds(),
+                    TimeUnit.SECONDS
+            );
+        } else {
+            this.cleanupExecutor = null;
+        }
+    }
+
+    /**
+     * Marks a session as revoked.
+     *
+     * @param sessionId the session ID to revoke
+     */
+    public void revokeSession(String sessionId) {
+        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        revokedSessions.put(sessionId, Instant.now().plus(revocationTtl));
+    }
+
+    /**
+     * Marks a session as revoked with a specific expiration time.
+     *
+     * @param sessionId  the session ID to revoke
+     * @param expiration when the revocation record should expire
+     */
+    public void revokeSession(String sessionId, Instant expiration) {
+        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        Objects.requireNonNull(expiration, "expiration must not be null");
+        revokedSessions.put(sessionId, expiration);
+    }
+
+    /**
+     * Checks if a session has been revoked.
+     *
+     * @param sessionId the session ID to check
+     * @return true if the session has been revoked and the revocation hasn't expired
+     */
+    public boolean isRevoked(String sessionId) {
+        Objects.requireNonNull(sessionId, "sessionId must not be null");
+        var expiration = revokedSessions.get(sessionId);
+        if (expiration == null) {
+            return false;
+        }
+        if (Instant.now().isAfter(expiration)) {
+            // Revocation record has expired, remove it
+            revokedSessions.remove(sessionId, expiration);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Validates that a session is not revoked.
+     *
+     * @param sessionId the session ID to validate
+     * @throws TokenValidationException if the session has been revoked
+     */
+    public void validateSession(String sessionId) {
+        if (isRevoked(sessionId)) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.TOKEN_EXPIRED,
+                    "Session has been revoked");
+        }
+    }
+
+    /**
+     * Removes expired revocation records.
+     * <p>
+     * This is called automatically on a schedule, but can be called
+     * manually for testing or maintenance.
+     */
+    public void cleanupExpired() {
+        var now = Instant.now();
+        revokedSessions.entrySet().removeIf(entry -> now.isAfter(entry.getValue()));
+    }
+
+    /**
+     * Returns the number of revoked sessions currently stored.
+     *
+     * @return the number of revoked sessions
+     */
+    public int size() {
+        return revokedSessions.size();
+    }
+
+    /**
+     * Clears all revoked sessions.
+     */
+    public void clear() {
+        revokedSessions.clear();
+    }
+
+    /**
+     * Shuts down the cleanup executor and releases resources.
+     */
+    @Override
+    public void close() {
+        if (cleanupExecutor != null) {
+            cleanupExecutor.shutdown();
+            try {
+                if (!cleanupExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    cleanupExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                cleanupExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/TokenClaims.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/TokenClaims.java
@@ -1,0 +1,81 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Parsed and validated claims from a JWT access token.
+ *
+ * @param subject      the subject (user identifier) from the 'sub' claim
+ * @param issuer       the issuer from the 'iss' claim
+ * @param sessionId    the session ID from the 'sid' claim, or null if not present
+ * @param roles        the user's roles extracted from the token
+ * @param expiresAt    the token expiration time from the 'exp' claim
+ * @param issuedAt     the token issue time from the 'iat' claim, or null if not present
+ */
+public record TokenClaims(
+        String subject,
+        String issuer,
+        @Nullable String sessionId,
+        Set<Role> roles,
+        Instant expiresAt,
+        @Nullable Instant issuedAt
+) {
+
+    /**
+     * Creates token claims with validation.
+     */
+    public TokenClaims {
+        Objects.requireNonNull(subject, "subject must not be null");
+        Objects.requireNonNull(issuer, "issuer must not be null");
+        Objects.requireNonNull(roles, "roles must not be null");
+        Objects.requireNonNull(expiresAt, "expiresAt must not be null");
+
+        if (subject.isBlank()) {
+            throw new IllegalArgumentException("subject must not be blank");
+        }
+        if (issuer.isBlank()) {
+            throw new IllegalArgumentException("issuer must not be blank");
+        }
+
+        // Make roles immutable
+        roles = Set.copyOf(roles);
+    }
+
+    /**
+     * Checks if the token has expired.
+     *
+     * @return true if the token has expired
+     */
+    public boolean isExpired() {
+        return Instant.now().isAfter(expiresAt);
+    }
+
+    /**
+     * Checks if the user has the specified role.
+     *
+     * @param role the role to check
+     * @return true if the user has the role
+     */
+    public boolean hasRole(Role role) {
+        return roles.contains(role);
+    }
+
+    /**
+     * Checks if the user has any of the specified roles.
+     *
+     * @param requiredRoles the roles to check
+     * @return true if the user has at least one of the roles
+     */
+    public boolean hasAnyRole(Role... requiredRoles) {
+        for (Role role : requiredRoles) {
+            if (roles.contains(role)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/TokenValidationException.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/TokenValidationException.java
@@ -1,0 +1,76 @@
+package net.pkhapps.idispatchx.common.auth;
+
+/**
+ * Exception thrown when JWT token validation fails.
+ */
+public class TokenValidationException extends RuntimeException {
+
+    /**
+     * Error codes for token validation failures.
+     */
+    public enum ErrorCode {
+        /**
+         * Token is malformed or cannot be parsed.
+         */
+        INVALID_TOKEN,
+
+        /**
+         * Token signature verification failed.
+         */
+        INVALID_SIGNATURE,
+
+        /**
+         * Token has expired.
+         */
+        TOKEN_EXPIRED,
+
+        /**
+         * Token issuer does not match expected issuer.
+         */
+        INVALID_ISSUER,
+
+        /**
+         * Required claim is missing from the token.
+         */
+        MISSING_CLAIM,
+
+        /**
+         * Key for signature verification not found.
+         */
+        KEY_NOT_FOUND
+    }
+
+    private final ErrorCode errorCode;
+
+    /**
+     * Creates a new token validation exception.
+     *
+     * @param errorCode the error code
+     * @param message   the error message
+     */
+    public TokenValidationException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Creates a new token validation exception with a cause.
+     *
+     * @param errorCode the error code
+     * @param message   the error message
+     * @param cause     the underlying cause
+     */
+    public TokenValidationException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Returns the error code.
+     *
+     * @return the error code
+     */
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/TokenValidator.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/TokenValidator.java
@@ -1,0 +1,238 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Validates JWT access tokens against a JWKS.
+ * <p>
+ * The validator verifies:
+ * <ul>
+ *   <li>Token signature using the JWKS</li>
+ *   <li>Token expiration (exp claim)</li>
+ *   <li>Token issuer matches expected issuer</li>
+ *   <li>Required claims are present</li>
+ * </ul>
+ * <p>
+ * This class is thread-safe.
+ */
+public final class TokenValidator {
+
+    private static final Logger log = LoggerFactory.getLogger(TokenValidator.class);
+
+    /**
+     * Default claim name for roles.
+     */
+    public static final String DEFAULT_ROLES_CLAIM = "roles";
+
+    private final JwksKeyProvider keyProvider;
+    private final String expectedIssuer;
+    private final String rolesClaim;
+
+    /**
+     * Creates a new token validator.
+     *
+     * @param keyProvider    the key provider for fetching signing keys
+     * @param expectedIssuer the expected token issuer (iss claim)
+     */
+    public TokenValidator(JwksKeyProvider keyProvider, String expectedIssuer) {
+        this(keyProvider, expectedIssuer, DEFAULT_ROLES_CLAIM);
+    }
+
+    /**
+     * Creates a new token validator with a custom roles claim name.
+     *
+     * @param keyProvider    the key provider for fetching signing keys
+     * @param expectedIssuer the expected token issuer (iss claim)
+     * @param rolesClaim     the claim name containing user roles
+     */
+    public TokenValidator(JwksKeyProvider keyProvider, String expectedIssuer, String rolesClaim) {
+        this.keyProvider = Objects.requireNonNull(keyProvider, "keyProvider must not be null");
+        this.expectedIssuer = Objects.requireNonNull(expectedIssuer, "expectedIssuer must not be null");
+        this.rolesClaim = Objects.requireNonNull(rolesClaim, "rolesClaim must not be null");
+
+        if (expectedIssuer.isBlank()) {
+            throw new IllegalArgumentException("expectedIssuer must not be blank");
+        }
+    }
+
+    /**
+     * Validates a JWT token and extracts its claims.
+     *
+     * @param token the JWT token string
+     * @return the validated token claims
+     * @throws TokenValidationException if validation fails
+     */
+    public TokenClaims validate(String token) {
+        Objects.requireNonNull(token, "token must not be null");
+
+        // Parse the token
+        SignedJWT signedJWT;
+        try {
+            signedJWT = SignedJWT.parse(token);
+        } catch (ParseException e) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Failed to parse JWT: " + e.getMessage(), e);
+        }
+
+        // Get the key ID from the token header
+        var keyId = signedJWT.getHeader().getKeyID();
+        if (keyId == null) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Token does not contain a key ID (kid)");
+        }
+
+        // Fetch the signing key
+        var jwk = keyProvider.getKey(keyId);
+        if (jwk == null) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.KEY_NOT_FOUND,
+                    "Signing key not found: " + keyId);
+        }
+
+        // Verify the signature
+        verifySignature(signedJWT, jwk);
+
+        // Extract and validate claims
+        JWTClaimsSet claims;
+        try {
+            claims = signedJWT.getJWTClaimsSet();
+        } catch (ParseException e) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Failed to extract claims: " + e.getMessage(), e);
+        }
+
+        return validateClaims(claims);
+    }
+
+    private void verifySignature(SignedJWT signedJWT, JWK jwk) {
+        try {
+            JWSVerifier verifier = createVerifier(jwk);
+            if (!signedJWT.verify(verifier)) {
+                throw new TokenValidationException(
+                        TokenValidationException.ErrorCode.INVALID_SIGNATURE,
+                        "Token signature verification failed");
+            }
+        } catch (JOSEException e) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_SIGNATURE,
+                    "Signature verification error: " + e.getMessage(), e);
+        }
+    }
+
+    private JWSVerifier createVerifier(JWK jwk) throws JOSEException {
+        if (jwk instanceof RSAKey rsaKey) {
+            return new RSASSAVerifier(rsaKey.toRSAPublicKey());
+        } else if (jwk instanceof ECKey ecKey) {
+            return new ECDSAVerifier(ecKey.toECPublicKey());
+        } else {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_TOKEN,
+                    "Unsupported key type: " + jwk.getKeyType());
+        }
+    }
+
+    private TokenClaims validateClaims(JWTClaimsSet claims) {
+        // Validate issuer
+        var issuer = claims.getIssuer();
+        if (issuer == null) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.MISSING_CLAIM,
+                    "Token does not contain issuer (iss) claim");
+        }
+        if (!expectedIssuer.equals(issuer)) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.INVALID_ISSUER,
+                    "Token issuer '" + issuer + "' does not match expected '" + expectedIssuer + "'");
+        }
+
+        // Validate expiration
+        var expirationTime = claims.getExpirationTime();
+        if (expirationTime == null) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.MISSING_CLAIM,
+                    "Token does not contain expiration (exp) claim");
+        }
+        if (expirationTime.before(new Date())) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.TOKEN_EXPIRED,
+                    "Token has expired");
+        }
+
+        // Validate subject
+        var subject = claims.getSubject();
+        if (subject == null || subject.isBlank()) {
+            throw new TokenValidationException(
+                    TokenValidationException.ErrorCode.MISSING_CLAIM,
+                    "Token does not contain subject (sub) claim");
+        }
+
+        // Extract roles
+        var roles = extractRoles(claims);
+
+        // Extract optional claims
+        var sessionId = getStringClaim(claims, "sid");
+        var issuedAt = claims.getIssueTime() != null
+                ? claims.getIssueTime().toInstant()
+                : null;
+
+        return new TokenClaims(
+                subject,
+                issuer,
+                sessionId,
+                roles,
+                expirationTime.toInstant(),
+                issuedAt
+        );
+    }
+
+    private Set<Role> extractRoles(JWTClaimsSet claims) {
+        Set<Role> roles = new HashSet<>();
+
+        try {
+            var rolesClaim = claims.getClaim(this.rolesClaim);
+            if (rolesClaim instanceof List<?> roleList) {
+                for (Object item : roleList) {
+                    if (item instanceof String roleStr) {
+                        Role.fromClaimValue(roleStr).ifPresent(roles::add);
+                    }
+                }
+            } else if (rolesClaim instanceof String roleStr) {
+                // Some providers might send a single role as a string
+                Role.fromClaimValue(roleStr).ifPresent(roles::add);
+            }
+        } catch (Exception e) {
+            log.debug("Failed to extract roles from claim '{}': {}", this.rolesClaim, e.getMessage());
+        }
+
+        return roles;
+    }
+
+    private @Nullable String getStringClaim(JWTClaimsSet claims, String claimName) {
+        try {
+            return claims.getStringClaim(claimName);
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/package-info.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/auth/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Authentication and authorization infrastructure shared between servers.
+ * <p>
+ * This package provides JWT validation, JWKS handling, role-based authorization,
+ * and session management for OIDC back channel logout support.
+ */
+@NullMarked
+package net.pkhapps.idispatchx.common.auth;
+
+import org.jspecify.annotations.NullMarked;

--- a/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/JwksClientTest.java
+++ b/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/JwksClientTest.java
@@ -1,0 +1,341 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwksClientTest {
+
+    private static final URI TEST_JWKS_URI = URI.create("https://test.example.com/.well-known/jwks.json");
+
+    @Test
+    void constructor_rejectsNullJwksUri() {
+        assertThrows(NullPointerException.class, () -> new JwksClient(null));
+    }
+
+    @Test
+    void constructor_rejectsNullCacheTtl() {
+        assertThrows(NullPointerException.class, () ->
+                new JwksClient(TEST_JWKS_URI, null, HttpClient.newHttpClient()));
+    }
+
+    @Test
+    void constructor_rejectsNullHttpClient() {
+        assertThrows(NullPointerException.class, () ->
+                new JwksClient(TEST_JWKS_URI, Duration.ofMinutes(5), null));
+    }
+
+    @Test
+    void constructor_rejectsNegativeCacheTtl() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new JwksClient(TEST_JWKS_URI, Duration.ofMinutes(-1), HttpClient.newHttpClient()));
+    }
+
+    @Test
+    void constructor_rejectsZeroCacheTtl() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new JwksClient(TEST_JWKS_URI, Duration.ZERO, HttpClient.newHttpClient()));
+    }
+
+    @Test
+    void getJwksUri_returnsConfiguredUri() {
+        var client = new JwksClient(TEST_JWKS_URI, Duration.ofMinutes(5), createMockHttpClient("{}"));
+        assertEquals(TEST_JWKS_URI, client.getJwksUri());
+    }
+
+    @Test
+    void getKey_nullKeyIdThrowsException() {
+        var client = new JwksClient(TEST_JWKS_URI, Duration.ofMinutes(5), createMockHttpClient("{}"));
+        assertThrows(NullPointerException.class, () -> client.getKey(null));
+    }
+
+    @Test
+    void getKey_fetchesAndCachesJwks() throws Exception {
+        var key = new RSAKeyGenerator(2048).keyID("test-key").generate();
+        var jwkSet = new JWKSet(key);
+        var fetchCount = new AtomicInteger(0);
+
+        var client = new JwksClient(TEST_JWKS_URI, Duration.ofMinutes(5),
+                createMockHttpClient(jwkSet.toString(), fetchCount));
+
+        // First call should fetch
+        var result1 = client.getKey("test-key");
+        assertNotNull(result1);
+        assertEquals("test-key", result1.getKeyID());
+        assertEquals(1, fetchCount.get());
+
+        // Second call should use cache
+        var result2 = client.getKey("test-key");
+        assertNotNull(result2);
+        assertEquals(1, fetchCount.get());
+    }
+
+    @Test
+    void getKey_returnsNullForUnknownKey() throws Exception {
+        var key = new RSAKeyGenerator(2048).keyID("known-key").generate();
+        var jwkSet = new JWKSet(key);
+
+        var client = new JwksClient(TEST_JWKS_URI, Duration.ofMinutes(5),
+                createMockHttpClient(jwkSet.toString()));
+
+        var result = client.getKey("unknown-key");
+        assertNull(result);
+    }
+
+    @Test
+    void getKey_refreshesOnKeyNotFound() throws Exception {
+        var key1 = new RSAKeyGenerator(2048).keyID("key1").generate();
+        var key2 = new RSAKeyGenerator(2048).keyID("key2").generate();
+
+        // First request returns key1, second request returns key1 + key2
+        var jwkSet1 = new JWKSet(key1);
+        var jwkSet2 = new JWKSet(java.util.List.of(key1, key2));
+
+        var responses = new String[]{jwkSet1.toString(), jwkSet2.toString()};
+        var fetchCount = new AtomicInteger(0);
+
+        // Use very short TTL to ensure cache expires between calls
+        var client = new JwksClient(TEST_JWKS_URI, Duration.ofMillis(1),
+                createSequentialMockHttpClient(responses, fetchCount));
+
+        // Get key1 - should fetch
+        var result1 = client.getKey("key1");
+        assertNotNull(result1);
+        assertEquals(1, fetchCount.get());
+
+        // Wait for cache to expire
+        Thread.sleep(10);
+
+        // Get key2 - cache expired, should refresh and find key2
+        var result2 = client.getKey("key2");
+        assertNotNull(result2);
+        assertEquals("key2", result2.getKeyID());
+        assertEquals(2, fetchCount.get());
+    }
+
+    @Test
+    void refresh_clearsCache() throws Exception {
+        var key = new RSAKeyGenerator(2048).keyID("test-key").generate();
+        var jwkSet = new JWKSet(key);
+        var fetchCount = new AtomicInteger(0);
+
+        var client = new JwksClient(TEST_JWKS_URI, Duration.ofMinutes(5),
+                createMockHttpClient(jwkSet.toString(), fetchCount));
+
+        // First call
+        client.getKey("test-key");
+        assertEquals(1, fetchCount.get());
+
+        // Force refresh
+        client.refresh();
+
+        // Next call should fetch again
+        client.getKey("test-key");
+        assertEquals(2, fetchCount.get());
+    }
+
+    @Test
+    void getKey_throwsJwksExceptionOnHttpError() {
+        var client = new JwksClient(TEST_JWKS_URI, Duration.ofMinutes(5),
+                createErrorHttpClient(500));
+
+        assertThrows(JwksException.class, () -> client.getKey("any-key"));
+    }
+
+    @Test
+    void getKey_throwsJwksExceptionOnInvalidJson() {
+        var client = new JwksClient(TEST_JWKS_URI, Duration.ofMinutes(5),
+                createMockHttpClient("not valid json"));
+
+        assertThrows(JwksException.class, () -> client.getKey("any-key"));
+    }
+
+    @Test
+    void defaultCacheTtlIsFiveMinutes() {
+        assertEquals(Duration.ofMinutes(5), JwksClient.DEFAULT_CACHE_TTL);
+    }
+
+    @Test
+    void defaultTimeoutIsTenSeconds() {
+        assertEquals(Duration.ofSeconds(10), JwksClient.DEFAULT_TIMEOUT);
+    }
+
+    // Test helper methods
+
+    private HttpClient createMockHttpClient(String responseBody) {
+        return createMockHttpClient(responseBody, new AtomicInteger());
+    }
+
+    private HttpClient createMockHttpClient(String responseBody, AtomicInteger fetchCount) {
+        return new MockHttpClient(responseBody, 200, fetchCount);
+    }
+
+    private HttpClient createSequentialMockHttpClient(String[] responses, AtomicInteger fetchCount) {
+        return new SequentialMockHttpClient(responses, fetchCount);
+    }
+
+    private HttpClient createErrorHttpClient(int statusCode) {
+        return new MockHttpClient("Error", statusCode, new AtomicInteger());
+    }
+
+    /**
+     * Mock HttpClient that returns a fixed response.
+     */
+    private static class MockHttpClient extends HttpClient {
+        private final String responseBody;
+        private final int statusCode;
+        private final AtomicInteger fetchCount;
+
+        MockHttpClient(String responseBody, int statusCode, AtomicInteger fetchCount) {
+            this.responseBody = responseBody;
+            this.statusCode = statusCode;
+            this.fetchCount = fetchCount;
+        }
+
+        @Override
+        public java.util.Optional<java.net.CookieHandler> cookieHandler() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.net.http.HttpClient.Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+
+        @Override
+        public java.util.Optional<java.net.ProxySelector> proxy() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public javax.net.ssl.SSLContext sslContext() {
+            return null;
+        }
+
+        @Override
+        public javax.net.ssl.SSLParameters sslParameters() {
+            return null;
+        }
+
+        @Override
+        public java.util.Optional<java.util.concurrent.Executor> executor() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<java.net.Authenticator> authenticator() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.net.http.HttpClient.Version version() {
+            return Version.HTTP_1_1;
+        }
+
+        @Override
+        public java.util.Optional<java.time.Duration> connectTimeout() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+                throws IOException, InterruptedException {
+            fetchCount.incrementAndGet();
+            return (HttpResponse<T>) new MockHttpResponse(responseBody, statusCode);
+        }
+
+        @Override
+        public <T> java.util.concurrent.CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> java.util.concurrent.CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler,
+                HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * Mock HttpClient that returns different responses sequentially.
+     */
+    private static class SequentialMockHttpClient extends MockHttpClient {
+        private final String[] responses;
+        private final AtomicInteger index = new AtomicInteger(0);
+        private final AtomicInteger sequentialFetchCount;
+
+        SequentialMockHttpClient(String[] responses, AtomicInteger fetchCount) {
+            super("", 200, fetchCount);
+            this.responses = responses;
+            this.sequentialFetchCount = fetchCount;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+                throws IOException, InterruptedException {
+            sequentialFetchCount.incrementAndGet();
+            var i = index.getAndIncrement();
+            var response = i < responses.length ? responses[i] : responses[responses.length - 1];
+            return (HttpResponse<T>) new MockHttpResponse(response, 200);
+        }
+    }
+
+    /**
+     * Mock HttpResponse.
+     */
+    private record MockHttpResponse(String body, int statusCode) implements HttpResponse<String> {
+        @Override
+        public int statusCode() {
+            return statusCode;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return null;
+        }
+
+        @Override
+        public java.util.Optional<HttpResponse<String>> previousResponse() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.net.http.HttpHeaders headers() {
+            return java.net.http.HttpHeaders.of(java.util.Map.of(), (a, b) -> true);
+        }
+
+        @Override
+        public String body() {
+            return body;
+        }
+
+        @Override
+        public java.util.Optional<javax.net.ssl.SSLSession> sslSession() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return TEST_JWKS_URI;
+        }
+
+        @Override
+        public java.net.http.HttpClient.Version version() {
+            return java.net.http.HttpClient.Version.HTTP_1_1;
+        }
+    }
+}

--- a/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/LogoutTokenValidatorTest.java
+++ b/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/LogoutTokenValidatorTest.java
@@ -1,0 +1,302 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogoutTokenValidatorTest {
+
+    private static final String EXPECTED_ISSUER = "https://issuer.example.com";
+    private static final String EXPECTED_AUDIENCE = "gis-server-client";
+    private static final String KEY_ID = "logout-key-1";
+
+    private RSAKey rsaKey;
+    private TestJwksKeyProvider keyProvider;
+    private LogoutTokenValidator validator;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        rsaKey = new RSAKeyGenerator(2048).keyID(KEY_ID).generate();
+        keyProvider = new TestJwksKeyProvider();
+        keyProvider.addKey(rsaKey);
+        validator = new LogoutTokenValidator(keyProvider, EXPECTED_ISSUER, EXPECTED_AUDIENCE);
+    }
+
+    @Test
+    void constructor_rejectsNullKeyProvider() {
+        assertThrows(NullPointerException.class, () ->
+                new LogoutTokenValidator(null, EXPECTED_ISSUER, EXPECTED_AUDIENCE));
+    }
+
+    @Test
+    void constructor_rejectsNullExpectedIssuer() {
+        assertThrows(NullPointerException.class, () ->
+                new LogoutTokenValidator(keyProvider, null, EXPECTED_AUDIENCE));
+    }
+
+    @Test
+    void constructor_rejectsNullExpectedAudience() {
+        assertThrows(NullPointerException.class, () ->
+                new LogoutTokenValidator(keyProvider, EXPECTED_ISSUER, null));
+    }
+
+    @Test
+    void constructor_rejectsBlankExpectedIssuer() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new LogoutTokenValidator(keyProvider, "", EXPECTED_AUDIENCE));
+        assertThrows(IllegalArgumentException.class, () ->
+                new LogoutTokenValidator(keyProvider, "   ", EXPECTED_AUDIENCE));
+    }
+
+    @Test
+    void constructor_rejectsBlankExpectedAudience() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new LogoutTokenValidator(keyProvider, EXPECTED_ISSUER, ""));
+        assertThrows(IllegalArgumentException.class, () ->
+                new LogoutTokenValidator(keyProvider, EXPECTED_ISSUER, "   "));
+    }
+
+    @Test
+    void validate_rejectsNullToken() {
+        assertThrows(NullPointerException.class, () -> validator.validate(null));
+    }
+
+    @Test
+    void validate_rejectsInvalidTokenFormat() {
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate("not.a.valid.jwt"));
+        assertEquals(TokenValidationException.ErrorCode.INVALID_TOKEN, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_acceptsValidLogoutToken() throws Exception {
+        var claims = createValidLogoutClaims()
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var result = validator.validate(token);
+
+        assertNotNull(result);
+        assertEquals("session-123", result.sessionId());
+    }
+
+    @Test
+    void validate_acceptsLogoutTokenWithSubjectOnly() throws Exception {
+        var claims = createValidLogoutClaims()
+                .subject("user-456")
+                .build();
+        var token = createToken(claims);
+
+        var result = validator.validate(token);
+
+        assertNotNull(result);
+        assertNull(result.sessionId());
+        assertEquals("user-456", result.subject());
+        assertTrue(result.isSubjectLogout());
+    }
+
+    @Test
+    void validate_rejectsTokenWithWrongIssuer() throws Exception {
+        var claims = createValidLogoutClaims()
+                .issuer("https://wrong-issuer.example.com")
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.INVALID_ISSUER, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsTokenWithoutIssuer() throws Exception {
+        var claims = new JWTClaimsSet.Builder()
+                .audience(EXPECTED_AUDIENCE)
+                .claim("events", createLogoutEventsMap())
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.MISSING_CLAIM, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsTokenWithWrongAudience() throws Exception {
+        var claims = createValidLogoutClaims()
+                .audience("wrong-client")
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.INVALID_TOKEN, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsTokenWithoutAudience() throws Exception {
+        var claims = new JWTClaimsSet.Builder()
+                .issuer(EXPECTED_ISSUER)
+                .claim("events", createLogoutEventsMap())
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.MISSING_CLAIM, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsExpiredToken() throws Exception {
+        var claims = createValidLogoutClaims()
+                .expirationTime(Date.from(Instant.now().minusSeconds(120))) // 2 minutes ago
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.TOKEN_EXPIRED, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_allowsClockSkew() throws Exception {
+        // Token that "expired" 30 seconds ago should still be valid (60s skew allowed)
+        var claims = createValidLogoutClaims()
+                .expirationTime(Date.from(Instant.now().minusSeconds(30)))
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var result = validator.validate(token);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void validate_rejectsTokenWithoutEvents() throws Exception {
+        var claims = new JWTClaimsSet.Builder()
+                .issuer(EXPECTED_ISSUER)
+                .audience(EXPECTED_AUDIENCE)
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.MISSING_CLAIM, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsTokenWithWrongEventType() throws Exception {
+        var claims = createValidLogoutClaims()
+                .claim("events", Map.of("http://wrong.event/type", Map.of()))
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.INVALID_TOKEN, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsTokenWithNonce() throws Exception {
+        var claims = createValidLogoutClaims()
+                .claim("nonce", "some-nonce-value")
+                .claim("sid", "session-123")
+                .build();
+        var token = createToken(claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.INVALID_TOKEN, ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("nonce"));
+    }
+
+    @Test
+    void validate_rejectsTokenWithoutSidOrSub() throws Exception {
+        var claims = createValidLogoutClaims().build();
+        var token = createToken(claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.MISSING_CLAIM, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_acceptsTokenWithBothSidAndSub() throws Exception {
+        var claims = createValidLogoutClaims()
+                .claim("sid", "session-123")
+                .subject("user-456")
+                .build();
+        var token = createToken(claims);
+
+        var result = validator.validate(token);
+
+        assertEquals("session-123", result.sessionId());
+        assertEquals("user-456", result.subject());
+        assertTrue(result.hasSessionId());
+        assertFalse(result.isSubjectLogout());
+    }
+
+    @Test
+    void logoutEventTypeConstant() {
+        assertEquals("http://schemas.openid.net/event/backchannel-logout",
+                LogoutTokenValidator.LOGOUT_EVENT_TYPE);
+    }
+
+    // Helper methods
+
+    private JWTClaimsSet.Builder createValidLogoutClaims() {
+        return new JWTClaimsSet.Builder()
+                .issuer(EXPECTED_ISSUER)
+                .audience(EXPECTED_AUDIENCE)
+                .claim("events", createLogoutEventsMap());
+    }
+
+    private Map<String, Object> createLogoutEventsMap() {
+        return Map.of(LogoutTokenValidator.LOGOUT_EVENT_TYPE, Map.of());
+    }
+
+    private String createToken(JWTClaimsSet claims) throws Exception {
+        var header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .keyID(rsaKey.getKeyID())
+                .build();
+        var jwt = new SignedJWT(header, claims);
+        jwt.sign(new RSASSASigner(rsaKey));
+        return jwt.serialize();
+    }
+
+    private static class TestJwksKeyProvider implements JwksKeyProvider {
+        private final Map<String, JWK> keys = new ConcurrentHashMap<>();
+
+        void addKey(JWK key) {
+            keys.put(key.getKeyID(), key);
+        }
+
+        @Override
+        public @Nullable JWK getKey(String keyId) {
+            return keys.get(keyId);
+        }
+    }
+}

--- a/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/RoleTest.java
+++ b/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/RoleTest.java
@@ -1,0 +1,52 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoleTest {
+
+    @ParameterizedTest
+    @EnumSource(Role.class)
+    void fromClaimValue_findsAllRoles(Role role) {
+        var found = Role.fromClaimValue(role.getClaimValue());
+        assertTrue(found.isPresent());
+        assertEquals(role, found.get());
+    }
+
+    @Test
+    void fromClaimValue_caseInsensitive() {
+        assertEquals(Role.DISPATCHER, Role.fromClaimValue("dispatcher").orElse(null));
+        assertEquals(Role.DISPATCHER, Role.fromClaimValue("DISPATCHER").orElse(null));
+        assertEquals(Role.ADMIN, Role.fromClaimValue("admin").orElse(null));
+        assertEquals(Role.OBSERVER, Role.fromClaimValue("OBSERVER").orElse(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "Unknown", "SUPERUSER", "root"})
+    void fromClaimValue_returnsEmptyForUnknownRoles(String claimValue) {
+        var result = Role.fromClaimValue(claimValue);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getClaimValue_returnsExpectedValues() {
+        assertEquals("Dispatcher", Role.DISPATCHER.getClaimValue());
+        assertEquals("Observer", Role.OBSERVER.getClaimValue());
+        assertEquals("Admin", Role.ADMIN.getClaimValue());
+        assertEquals("Station", Role.STATION.getClaimValue());
+        assertEquals("Unit", Role.UNIT.getClaimValue());
+    }
+
+    @Test
+    void allRolesHaveUniqueClaimValues() {
+        var claimValues = java.util.Arrays.stream(Role.values())
+                .map(Role::getClaimValue)
+                .toList();
+        var uniqueClaimValues = new java.util.HashSet<>(claimValues);
+        assertEquals(claimValues.size(), uniqueClaimValues.size(), "All roles should have unique claim values");
+    }
+}

--- a/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/SessionStoreTest.java
+++ b/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/SessionStoreTest.java
@@ -1,0 +1,149 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionStoreTest {
+
+    private SessionStore sessionStore;
+
+    @BeforeEach
+    void setUp() {
+        // Create without scheduled cleanup for testing
+        sessionStore = new SessionStore(Duration.ofMinutes(5), false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        sessionStore.close();
+    }
+
+    @Test
+    void constructor_rejectsNullRevocationTtl() {
+        assertThrows(NullPointerException.class, () -> new SessionStore(null));
+    }
+
+    @Test
+    void constructor_rejectsNegativeRevocationTtl() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new SessionStore(Duration.ofMinutes(-1)));
+    }
+
+    @Test
+    void constructor_rejectsZeroRevocationTtl() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new SessionStore(Duration.ZERO));
+    }
+
+    @Test
+    void revokeSession_marksSessionAsRevoked() {
+        sessionStore.revokeSession("session-123");
+
+        assertTrue(sessionStore.isRevoked("session-123"));
+        assertEquals(1, sessionStore.size());
+    }
+
+    @Test
+    void revokeSession_rejectsNullSessionId() {
+        assertThrows(NullPointerException.class, () ->
+                sessionStore.revokeSession(null));
+    }
+
+    @Test
+    void revokeSessionWithExpiration_marksSessionAsRevoked() {
+        var expiration = Instant.now().plus(Duration.ofHours(1));
+        sessionStore.revokeSession("session-123", expiration);
+
+        assertTrue(sessionStore.isRevoked("session-123"));
+    }
+
+    @Test
+    void isRevoked_returnsFalseForUnknownSession() {
+        assertFalse(sessionStore.isRevoked("unknown-session"));
+    }
+
+    @Test
+    void isRevoked_returnsFalseForExpiredRevocation() {
+        var expiration = Instant.now().minus(Duration.ofSeconds(1));
+        sessionStore.revokeSession("session-123", expiration);
+
+        assertFalse(sessionStore.isRevoked("session-123"));
+    }
+
+    @Test
+    void isRevoked_rejectsNullSessionId() {
+        assertThrows(NullPointerException.class, () ->
+                sessionStore.isRevoked(null));
+    }
+
+    @Test
+    void validateSession_throwsForRevokedSession() {
+        sessionStore.revokeSession("session-123");
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                sessionStore.validateSession("session-123"));
+        assertEquals(TokenValidationException.ErrorCode.TOKEN_EXPIRED, ex.getErrorCode());
+    }
+
+    @Test
+    void validateSession_passesForUnknownSession() {
+        assertDoesNotThrow(() -> sessionStore.validateSession("unknown-session"));
+    }
+
+    @Test
+    void cleanupExpired_removesExpiredRevocations() {
+        var expired = Instant.now().minus(Duration.ofSeconds(1));
+        var valid = Instant.now().plus(Duration.ofHours(1));
+
+        sessionStore.revokeSession("expired-session", expired);
+        sessionStore.revokeSession("valid-session", valid);
+        assertEquals(2, sessionStore.size());
+
+        sessionStore.cleanupExpired();
+
+        assertEquals(1, sessionStore.size());
+        assertFalse(sessionStore.isRevoked("expired-session"));
+        assertTrue(sessionStore.isRevoked("valid-session"));
+    }
+
+    @Test
+    void clear_removesAllRevocations() {
+        sessionStore.revokeSession("session-1");
+        sessionStore.revokeSession("session-2");
+        sessionStore.revokeSession("session-3");
+        assertEquals(3, sessionStore.size());
+
+        sessionStore.clear();
+
+        assertEquals(0, sessionStore.size());
+    }
+
+    @Test
+    void defaultRevocationTtlIsOneHour() {
+        assertEquals(Duration.ofHours(1), SessionStore.DEFAULT_REVOCATION_TTL);
+    }
+
+    @Test
+    void multipleRevocationsOfSameSession() {
+        sessionStore.revokeSession("session-123");
+        sessionStore.revokeSession("session-123");
+
+        assertEquals(1, sessionStore.size());
+        assertTrue(sessionStore.isRevoked("session-123"));
+    }
+
+    @Test
+    void close_canBeCalledMultipleTimes() {
+        var store = new SessionStore(Duration.ofMinutes(5));
+        assertDoesNotThrow(() -> {
+            store.close();
+            store.close();
+        });
+    }
+}

--- a/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/TokenClaimsTest.java
+++ b/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/TokenClaimsTest.java
@@ -1,0 +1,143 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TokenClaimsTest {
+
+    @Test
+    void constructor_validatesRequiredFields() {
+        assertThrows(NullPointerException.class, () ->
+                new TokenClaims(null, "issuer", null, Set.of(), Instant.now().plusSeconds(3600), null));
+
+        assertThrows(NullPointerException.class, () ->
+                new TokenClaims("subject", null, null, Set.of(), Instant.now().plusSeconds(3600), null));
+
+        assertThrows(NullPointerException.class, () ->
+                new TokenClaims("subject", "issuer", null, null, Instant.now().plusSeconds(3600), null));
+
+        assertThrows(NullPointerException.class, () ->
+                new TokenClaims("subject", "issuer", null, Set.of(), null, null));
+    }
+
+    @Test
+    void constructor_rejectsBlankSubject() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new TokenClaims("", "issuer", null, Set.of(), Instant.now().plusSeconds(3600), null));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new TokenClaims("   ", "issuer", null, Set.of(), Instant.now().plusSeconds(3600), null));
+    }
+
+    @Test
+    void constructor_rejectsBlankIssuer() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new TokenClaims("subject", "", null, Set.of(), Instant.now().plusSeconds(3600), null));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new TokenClaims("subject", "   ", null, Set.of(), Instant.now().plusSeconds(3600), null));
+    }
+
+    @Test
+    void constructor_makesRolesImmutable() {
+        var mutableRoles = new java.util.HashSet<Role>();
+        mutableRoles.add(Role.DISPATCHER);
+
+        var claims = new TokenClaims("subject", "issuer", null, mutableRoles,
+                Instant.now().plusSeconds(3600), null);
+
+        assertThrows(UnsupportedOperationException.class, () ->
+                claims.roles().add(Role.ADMIN));
+    }
+
+    @Test
+    void isExpired_returnsTrueForExpiredToken() {
+        var claims = new TokenClaims("subject", "issuer", null, Set.of(),
+                Instant.now().minus(1, ChronoUnit.HOURS), null);
+        assertTrue(claims.isExpired());
+    }
+
+    @Test
+    void isExpired_returnsFalseForValidToken() {
+        var claims = new TokenClaims("subject", "issuer", null, Set.of(),
+                Instant.now().plus(1, ChronoUnit.HOURS), null);
+        assertFalse(claims.isExpired());
+    }
+
+    @Test
+    void hasRole_returnsTrueWhenRolePresent() {
+        var claims = new TokenClaims("subject", "issuer", null,
+                Set.of(Role.DISPATCHER, Role.OBSERVER),
+                Instant.now().plusSeconds(3600), null);
+
+        assertTrue(claims.hasRole(Role.DISPATCHER));
+        assertTrue(claims.hasRole(Role.OBSERVER));
+    }
+
+    @Test
+    void hasRole_returnsFalseWhenRoleAbsent() {
+        var claims = new TokenClaims("subject", "issuer", null,
+                Set.of(Role.DISPATCHER),
+                Instant.now().plusSeconds(3600), null);
+
+        assertFalse(claims.hasRole(Role.ADMIN));
+        assertFalse(claims.hasRole(Role.STATION));
+    }
+
+    @Test
+    void hasAnyRole_returnsTrueWhenAnyRolePresent() {
+        var claims = new TokenClaims("subject", "issuer", null,
+                Set.of(Role.DISPATCHER),
+                Instant.now().plusSeconds(3600), null);
+
+        assertTrue(claims.hasAnyRole(Role.DISPATCHER, Role.ADMIN));
+        assertTrue(claims.hasAnyRole(Role.ADMIN, Role.DISPATCHER));
+    }
+
+    @Test
+    void hasAnyRole_returnsFalseWhenNoRolesPresent() {
+        var claims = new TokenClaims("subject", "issuer", null,
+                Set.of(Role.DISPATCHER),
+                Instant.now().plusSeconds(3600), null);
+
+        assertFalse(claims.hasAnyRole(Role.ADMIN, Role.STATION));
+    }
+
+    @Test
+    void hasAnyRole_returnsFalseForEmptyRoles() {
+        var claims = new TokenClaims("subject", "issuer", null,
+                Set.of(),
+                Instant.now().plusSeconds(3600), null);
+
+        assertFalse(claims.hasAnyRole(Role.DISPATCHER, Role.ADMIN));
+    }
+
+    @Test
+    void optionalFieldsCanBeNull() {
+        var claims = new TokenClaims("subject", "issuer", null, Set.of(),
+                Instant.now().plusSeconds(3600), null);
+
+        assertNull(claims.sessionId());
+        assertNull(claims.issuedAt());
+    }
+
+    @Test
+    void allFieldsAccessible() {
+        var now = Instant.now();
+        var expiresAt = now.plusSeconds(3600);
+        var claims = new TokenClaims("user123", "https://issuer.example.com", "session456",
+                Set.of(Role.DISPATCHER, Role.ADMIN), expiresAt, now);
+
+        assertEquals("user123", claims.subject());
+        assertEquals("https://issuer.example.com", claims.issuer());
+        assertEquals("session456", claims.sessionId());
+        assertEquals(Set.of(Role.DISPATCHER, Role.ADMIN), claims.roles());
+        assertEquals(expiresAt, claims.expiresAt());
+        assertEquals(now, claims.issuedAt());
+    }
+}

--- a/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/TokenValidationExceptionTest.java
+++ b/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/TokenValidationExceptionTest.java
@@ -1,0 +1,57 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TokenValidationExceptionTest {
+
+    @ParameterizedTest
+    @EnumSource(TokenValidationException.ErrorCode.class)
+    void constructorWithMessage_preservesErrorCodeAndMessage(TokenValidationException.ErrorCode errorCode) {
+        var exception = new TokenValidationException(errorCode, "Test message");
+
+        assertEquals(errorCode, exception.getErrorCode());
+        assertEquals("Test message", exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    @ParameterizedTest
+    @EnumSource(TokenValidationException.ErrorCode.class)
+    void constructorWithCause_preservesAllFields(TokenValidationException.ErrorCode errorCode) {
+        var cause = new RuntimeException("Underlying error");
+        var exception = new TokenValidationException(errorCode, "Test message", cause);
+
+        assertEquals(errorCode, exception.getErrorCode());
+        assertEquals("Test message", exception.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+
+    @Test
+    void allErrorCodesExist() {
+        var errorCodes = TokenValidationException.ErrorCode.values();
+
+        assertTrue(contains(errorCodes, TokenValidationException.ErrorCode.INVALID_TOKEN));
+        assertTrue(contains(errorCodes, TokenValidationException.ErrorCode.INVALID_SIGNATURE));
+        assertTrue(contains(errorCodes, TokenValidationException.ErrorCode.TOKEN_EXPIRED));
+        assertTrue(contains(errorCodes, TokenValidationException.ErrorCode.INVALID_ISSUER));
+        assertTrue(contains(errorCodes, TokenValidationException.ErrorCode.MISSING_CLAIM));
+        assertTrue(contains(errorCodes, TokenValidationException.ErrorCode.KEY_NOT_FOUND));
+    }
+
+    private boolean contains(TokenValidationException.ErrorCode[] codes, TokenValidationException.ErrorCode code) {
+        for (var c : codes) {
+            if (c == code) return true;
+        }
+        return false;
+    }
+
+    @Test
+    void isRuntimeException() {
+        var exception = new TokenValidationException(
+                TokenValidationException.ErrorCode.INVALID_TOKEN, "Test");
+        assertTrue(exception instanceof RuntimeException);
+    }
+}

--- a/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/TokenValidatorTest.java
+++ b/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/auth/TokenValidatorTest.java
@@ -1,0 +1,354 @@
+package net.pkhapps.idispatchx.common.auth;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TokenValidatorTest {
+
+    private static final String EXPECTED_ISSUER = "https://issuer.example.com";
+    private static final String KEY_ID = "test-key-1";
+
+    private RSAKey rsaKey;
+    private TestJwksKeyProvider keyProvider;
+    private TokenValidator validator;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        rsaKey = new RSAKeyGenerator(2048).keyID(KEY_ID).generate();
+        keyProvider = new TestJwksKeyProvider();
+        keyProvider.addKey(rsaKey);
+        validator = new TokenValidator(keyProvider, EXPECTED_ISSUER);
+    }
+
+    @Test
+    void constructor_rejectsNullKeyProvider() {
+        assertThrows(NullPointerException.class, () ->
+                new TokenValidator(null, EXPECTED_ISSUER));
+    }
+
+    @Test
+    void constructor_rejectsNullExpectedIssuer() {
+        assertThrows(NullPointerException.class, () ->
+                new TokenValidator(keyProvider, null));
+    }
+
+    @Test
+    void constructor_rejectsBlankExpectedIssuer() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new TokenValidator(keyProvider, ""));
+        assertThrows(IllegalArgumentException.class, () ->
+                new TokenValidator(keyProvider, "   "));
+    }
+
+    @Test
+    void validate_rejectsNullToken() {
+        assertThrows(NullPointerException.class, () ->
+                validator.validate(null));
+    }
+
+    @Test
+    void validate_rejectsInvalidTokenFormat() {
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate("not.a.valid.jwt"));
+        assertEquals(TokenValidationException.ErrorCode.INVALID_TOKEN, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsTokenWithoutKeyId() throws Exception {
+        // Create token without key ID
+        var header = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
+        var claims = createValidClaims().build();
+        var token = createAndSignToken(header, claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.INVALID_TOKEN, ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("key ID"));
+    }
+
+    @Test
+    void validate_rejectsTokenWithUnknownKeyId() throws Exception {
+        var unknownKey = new RSAKeyGenerator(2048).keyID("unknown-key").generate();
+        var token = createValidToken(unknownKey);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.KEY_NOT_FOUND, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsTokenWithInvalidSignature() throws Exception {
+        // Create token signed with a different key
+        var differentKey = new RSAKeyGenerator(2048).keyID(KEY_ID).generate();
+        var token = createValidToken(differentKey);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.INVALID_SIGNATURE, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsExpiredToken() throws Exception {
+        var claims = createValidClaims()
+                .expirationTime(Date.from(Instant.now().minusSeconds(3600)))
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.TOKEN_EXPIRED, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsTokenWithoutExpiration() throws Exception {
+        var claims = new JWTClaimsSet.Builder()
+                .issuer(EXPECTED_ISSUER)
+                .subject("user123")
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.MISSING_CLAIM, ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("exp"));
+    }
+
+    @Test
+    void validate_rejectsTokenWithWrongIssuer() throws Exception {
+        var claims = createValidClaims()
+                .issuer("https://wrong-issuer.example.com")
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.INVALID_ISSUER, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_rejectsTokenWithoutIssuer() throws Exception {
+        var claims = new JWTClaimsSet.Builder()
+                .subject("user123")
+                .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.MISSING_CLAIM, ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("iss"));
+    }
+
+    @Test
+    void validate_rejectsTokenWithoutSubject() throws Exception {
+        var claims = new JWTClaimsSet.Builder()
+                .issuer(EXPECTED_ISSUER)
+                .expirationTime(Date.from(Instant.now().plusSeconds(3600)))
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.MISSING_CLAIM, ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("sub"));
+    }
+
+    @Test
+    void validate_rejectsTokenWithBlankSubject() throws Exception {
+        var claims = createValidClaims()
+                .subject("   ")
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var ex = assertThrows(TokenValidationException.class, () ->
+                validator.validate(token));
+        assertEquals(TokenValidationException.ErrorCode.MISSING_CLAIM, ex.getErrorCode());
+    }
+
+    @Test
+    void validate_acceptsValidToken() throws Exception {
+        var token = createValidToken(rsaKey);
+
+        var result = validator.validate(token);
+
+        assertNotNull(result);
+        assertEquals("user123", result.subject());
+        assertEquals(EXPECTED_ISSUER, result.issuer());
+    }
+
+    @Test
+    void validate_extractsRolesFromListClaim() throws Exception {
+        var claims = createValidClaims()
+                .claim("roles", List.of("Dispatcher", "Observer"))
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var result = validator.validate(token);
+
+        assertEquals(Set.of(Role.DISPATCHER, Role.OBSERVER), result.roles());
+    }
+
+    @Test
+    void validate_extractsRolesFromStringClaim() throws Exception {
+        var claims = createValidClaims()
+                .claim("roles", "Admin")
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var result = validator.validate(token);
+
+        assertEquals(Set.of(Role.ADMIN), result.roles());
+    }
+
+    @Test
+    void validate_ignoresUnknownRoles() throws Exception {
+        var claims = createValidClaims()
+                .claim("roles", List.of("Dispatcher", "UnknownRole", "Admin"))
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var result = validator.validate(token);
+
+        assertEquals(Set.of(Role.DISPATCHER, Role.ADMIN), result.roles());
+    }
+
+    @Test
+    void validate_returnsEmptyRolesWhenClaimMissing() throws Exception {
+        var claims = createValidClaims().build();
+        var token = createToken(rsaKey, claims);
+
+        var result = validator.validate(token);
+
+        assertTrue(result.roles().isEmpty());
+    }
+
+    @Test
+    void validate_extractsSessionId() throws Exception {
+        var claims = createValidClaims()
+                .claim("sid", "session-abc123")
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var result = validator.validate(token);
+
+        assertEquals("session-abc123", result.sessionId());
+    }
+
+    @Test
+    void validate_extractsIssuedAt() throws Exception {
+        var issuedAt = Instant.now().minusSeconds(60);
+        var claims = createValidClaims()
+                .issueTime(Date.from(issuedAt))
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var result = validator.validate(token);
+
+        assertNotNull(result.issuedAt());
+        // Compare with some tolerance for processing time
+        assertTrue(Math.abs(result.issuedAt().getEpochSecond() - issuedAt.getEpochSecond()) < 2);
+    }
+
+    @Test
+    void validate_worksWithEcKey() throws Exception {
+        var ecKey = new ECKeyGenerator(Curve.P_256).keyID("ec-key").generate();
+        keyProvider.addKey(ecKey);
+
+        var header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .keyID("ec-key")
+                .build();
+        var claims = createValidClaims().build();
+        var jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(ecKey));
+        var token = jwt.serialize();
+
+        var result = validator.validate(token);
+
+        assertNotNull(result);
+        assertEquals("user123", result.subject());
+    }
+
+    @Test
+    void validate_customRolesClaim() throws Exception {
+        var customValidator = new TokenValidator(keyProvider, EXPECTED_ISSUER, "realm_access");
+
+        var claims = createValidClaims()
+                .claim("realm_access", List.of("Dispatcher"))
+                .build();
+        var token = createToken(rsaKey, claims);
+
+        var result = customValidator.validate(token);
+
+        assertEquals(Set.of(Role.DISPATCHER), result.roles());
+    }
+
+    @Test
+    void defaultRolesClaim_isRoles() {
+        assertEquals("roles", TokenValidator.DEFAULT_ROLES_CLAIM);
+    }
+
+    // Helper methods
+
+    private JWTClaimsSet.Builder createValidClaims() {
+        return new JWTClaimsSet.Builder()
+                .issuer(EXPECTED_ISSUER)
+                .subject("user123")
+                .expirationTime(Date.from(Instant.now().plusSeconds(3600)));
+    }
+
+    private String createValidToken(RSAKey key) throws Exception {
+        return createToken(key, createValidClaims().build());
+    }
+
+    private String createToken(RSAKey key, JWTClaimsSet claims) throws Exception {
+        var header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .keyID(key.getKeyID())
+                .build();
+        var jwt = new SignedJWT(header, claims);
+        jwt.sign(new RSASSASigner(key));
+        return jwt.serialize();
+    }
+
+    private String createAndSignToken(JWSHeader header, JWTClaimsSet claims) throws Exception {
+        var jwt = new SignedJWT(header, claims);
+        jwt.sign(new RSASSASigner(rsaKey));
+        return jwt.serialize();
+    }
+
+    /**
+     * Test implementation of JwksKeyProvider that holds keys in memory.
+     */
+    private static class TestJwksKeyProvider implements JwksKeyProvider {
+        private final Map<String, JWK> keys = new ConcurrentHashMap<>();
+
+        void addKey(JWK key) {
+            keys.put(key.getKeyID(), key);
+        }
+
+        @Override
+        public @Nullable JWK getKey(String keyId) {
+            return keys.get(keyId);
+        }
+    }
+}

--- a/Spec/Plans/GIS-Server-Implementation-Plan.md
+++ b/Spec/Plans/GIS-Server-Implementation-Plan.md
@@ -20,7 +20,7 @@ This document contains the implementation plan for the GIS Server. It is organiz
 |-------|-------------|-------|--------|
 | 0 | Prerequisites | 2 | Done |
 | 1 | Foundation & Infrastructure | 5 | Done |
-| 2 | Authentication & Security | 5 | Not Started |
+| 2 | Authentication & Security | 5 | Done |
 | 3 | Model & Repository Layer | 5 | Not Started |
 | 4 | WMTS Tile Service | 6 | Not Started |
 | 5 | Geocoding Service | 8 | Not Started |
@@ -232,24 +232,26 @@ JWT validation, JWKS handling, role-based authorization, and back channel logout
 
 ### Task 2.1: Implement JWKS Client
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Fetch and cache JWKS from the OIDC provider.
 
 **Shared Module Package:** `net.pkhapps.idispatchx.common.auth`
 
-**Shared Module Files to Create:**
+**Shared Module Files Created:**
 - `JwksClient.java` - Fetches and caches JWKS
+- `JwksKeyProvider.java` - Interface for key providers
+- `JwksException.java` - Exception for JWKS operations
 
 **Acceptance Criteria:**
-- [ ] Fetches JWKS from configured URL on startup
-- [ ] Caches JWKS with configurable TTL
-- [ ] Refreshes JWKS when key not found (key rotation support)
-- [ ] Handles network errors gracefully
-- [ ] Uses Nimbus JOSE + JWT library
-- [ ] Shared module classes are in `java-common`
-- [ ] Unit tests with mocked HTTP responses
+- [x] Fetches JWKS from configured URL on startup
+- [x] Caches JWKS with configurable TTL
+- [x] Refreshes JWKS when key not found (key rotation support)
+- [x] Handles network errors gracefully
+- [x] Uses Nimbus JOSE + JWT library
+- [x] Shared module classes are in `java-common`
+- [x] Unit tests with mocked HTTP responses
 
 **Dependencies:** Task 1.1 (for OidcConfig)
 
@@ -257,16 +259,17 @@ Fetch and cache JWKS from the OIDC provider.
 
 ### Task 2.2: Implement Token Validator
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Validate JWT tokens against JWKS.
 
 **Shared Module Package:** `net.pkhapps.idispatchx.common.auth`
 
-**Shared Module Files to Create:**
+**Shared Module Files Created:**
 - `TokenValidator.java` - JWT signature and claims validation
 - `TokenClaims.java` - Parsed token claims record
+- `TokenValidationException.java` - Validation error with error codes
 
 **Validation Steps:**
 1. Verify JWT signature against JWKS
@@ -276,12 +279,12 @@ Validate JWT tokens against JWKS.
 5. Validate required role is present
 
 **Acceptance Criteria:**
-- [ ] Validates JWT signature using JWKS
-- [ ] Rejects expired tokens
-- [ ] Rejects tokens from wrong issuer
-- [ ] Extracts user identifier and roles
-- [ ] Returns clear validation error messages
-- [ ] Unit tests cover all validation scenarios
+- [x] Validates JWT signature using JWKS
+- [x] Rejects expired tokens
+- [x] Rejects tokens from wrong issuer
+- [x] Extracts user identifier and roles
+- [x] Returns clear validation error messages
+- [x] Unit tests cover all validation scenarios
 
 **Dependencies:** Task 2.1
 
@@ -289,23 +292,24 @@ Validate JWT tokens against JWKS.
 
 ### Task 2.3: Implement JWT Authentication Handler
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Javalin before-handler that validates JWT on protected endpoints. Uses the shared TokenValidator.
 
 **GIS Server Package:** `net.pkhapps.idispatchx.gis.server.auth`
 
-**GIS Server Files to Create:**
+**GIS Server Files Created:**
 - `JwtAuthHandler.java` - Javalin before-handler (uses shared TokenValidator)
+- `AuthContext.java` - Utility for accessing claims from Javalin context
 
 **Acceptance Criteria:**
-- [ ] Extracts Bearer token from Authorization header
-- [ ] Returns 401 if Authorization header missing
-- [ ] Returns 401 if token is invalid or expired
-- [ ] Stores validated claims in Javalin context for downstream handlers
-- [ ] Does not apply to health check endpoint
-- [ ] Unit tests verify authentication logic
+- [x] Extracts Bearer token from Authorization header
+- [x] Returns 401 if Authorization header missing
+- [x] Returns 401 if token is invalid or expired
+- [x] Stores validated claims in Javalin context for downstream handlers
+- [x] Does not apply to health check endpoint
+- [x] Unit tests verify authentication logic
 
 **Dependencies:** Task 2.2, Task 1.3
 
@@ -313,27 +317,27 @@ Javalin before-handler that validates JWT on protected endpoints. Uses the share
 
 ### Task 2.4: Implement Role Authorization
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Verify user has required role (`Dispatcher` or `Observer`) for GIS Server access.
 
 **Shared Module Package:** `net.pkhapps.idispatchx.common.auth`
 
-**Shared Module Files to Create:**
+**Shared Module Files Created:**
 - `Role.java` - Enum of system roles (Dispatcher, Observer, Admin, Station, Unit)
 
 **GIS Server Package:** `net.pkhapps.idispatchx.gis.server.auth`
 
-**GIS Server Files to Create:**
+**GIS Server Files Created:**
 - `RoleAuthHandler.java` - Javalin handler that checks role claims
 
 **Acceptance Criteria:**
-- [ ] Allows access if user has `Dispatcher` role
-- [ ] Allows access if user has `Observer` role
-- [ ] Returns 403 Forbidden if user lacks required role
-- [ ] Error response follows standard format
-- [ ] Unit tests cover role validation
+- [x] Allows access if user has `Dispatcher` role
+- [x] Allows access if user has `Observer` role
+- [x] Returns 403 Forbidden if user lacks required role
+- [x] Error response follows standard format
+- [x] Unit tests cover role validation
 
 **Dependencies:** Task 2.3
 
@@ -341,29 +345,29 @@ Verify user has required role (`Dispatcher` or `Observer`) for GIS Server access
 
 ### Task 2.5: Implement Back Channel Logout Handler
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Handle OIDC back channel logout events to invalidate sessions.
 
 **Shared Module Package:** `net.pkhapps.idispatchx.common.auth`
 
-**Shared Module Files to Create:**
+**Shared Module Files Created:**
 - `SessionStore.java` - In-memory session tracking (thread-safe)
 - `LogoutTokenValidator.java` - Validates OIDC logout tokens
 
 **GIS Server Package:** `net.pkhapps.idispatchx.gis.server.auth`
 
-**GIS Server Files to Create:**
+**GIS Server Files Created:**
 - `BackChannelLogoutHandler.java` - Javalin endpoint handler for logout events
 
 **Acceptance Criteria:**
-- [ ] Receives logout token from OIDC provider
-- [ ] Validates logout token signature
-- [ ] Extracts `sid` (session ID) claim
-- [ ] Invalidates session in SessionStore
-- [ ] Subsequent requests with invalidated session return 401
-- [ ] Unit tests verify logout flow
+- [x] Receives logout token from OIDC provider
+- [x] Validates logout token signature
+- [x] Extracts `sid` (session ID) claim
+- [x] Invalidates session in SessionStore
+- [x] Subsequent requests with invalidated session return 401
+- [x] Unit tests verify logout flow
 
 **Dependencies:** Task 2.2
 


### PR DESCRIPTION
## Summary

- Implements Phase 2 of the GIS Server implementation plan
- Adds JWT authentication and authorization infrastructure
- Shared auth components in `java-common` module for reuse by CAD Server
- GIS Server-specific Javalin handlers in `gis-server` module

## Changes

### Shared Module (`java-common`) - Auth Package (9 files)

| File | Description |
|------|-------------|
| `JwksClient.java` | Fetches and caches JWKS from OIDC provider with TTL-based caching |
| `JwksKeyProvider.java` | Interface for testable key providers |
| `JwksException.java` | Exception for JWKS operations |
| `TokenValidator.java` | Validates JWT tokens (signature, expiration, issuer, claims) |
| `TokenClaims.java` | Record containing parsed token claims |
| `TokenValidationException.java` | Validation errors with typed error codes |
| `Role.java` | Enum of system roles (Dispatcher, Observer, Admin, Station, Unit) |
| `SessionStore.java` | Thread-safe in-memory store for revoked sessions |
| `LogoutTokenValidator.java` | Validates OIDC back-channel logout tokens |

### GIS Server - Auth Package (5 files)

| File | Description |
|------|-------------|
| `JwtAuthHandler.java` | Javalin handler that extracts and validates Bearer tokens |
| `RoleAuthHandler.java` | Javalin handler for role-based authorization |
| `AuthContext.java` | Utility for accessing authenticated user info from context |
| `BackChannelLogoutHandler.java` | Handles OIDC logout notifications |
| `package-info.java` | Package documentation |

### Tests (7 files, 114 tests)

- `RoleTest.java` (12 tests)
- `TokenClaimsTest.java` (13 tests)
- `TokenValidationExceptionTest.java` (14 tests)
- `JwksClientTest.java` (15 tests) - with mock HTTP client
- `TokenValidatorTest.java` (24 tests) - with test key provider
- `SessionStoreTest.java` (16 tests)
- `LogoutTokenValidatorTest.java` (21 tests)

## Test plan

- [x] All 344 tests pass (`mvn test -pl servers/gis-server -am`)
- [x] Implementation plan updated to mark Phase 2 as Done
- [ ] Code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)