### PR TITLE
GIS Server Phase 5: Geocoding Service

### DIFF
--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/GisServer.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/GisServer.java
@@ -9,6 +9,7 @@ import net.pkhapps.idispatchx.common.auth.LogoutTokenValidator;
 import net.pkhapps.idispatchx.common.auth.Role;
 import net.pkhapps.idispatchx.common.auth.SessionStore;
 import net.pkhapps.idispatchx.common.auth.TokenValidator;
+import net.pkhapps.idispatchx.gis.server.api.geocode.GeocodeController;
 import net.pkhapps.idispatchx.gis.server.api.wmts.CapabilitiesGenerator;
 import net.pkhapps.idispatchx.gis.server.api.wmts.WmtsController;
 import net.pkhapps.idispatchx.gis.server.auth.BackChannelLogoutHandler;
@@ -18,6 +19,14 @@ import net.pkhapps.idispatchx.gis.server.config.GisServerConfig;
 import net.pkhapps.idispatchx.gis.server.db.DataSourceProvider;
 import net.pkhapps.idispatchx.gis.server.db.FlywayMigrator;
 import net.pkhapps.idispatchx.gis.server.db.JooqContextProvider;
+import net.pkhapps.idispatchx.gis.server.repository.AddressPointRepository;
+import net.pkhapps.idispatchx.gis.server.repository.NamedPlaceRepository;
+import net.pkhapps.idispatchx.gis.server.repository.RoadSegmentRepository;
+import net.pkhapps.idispatchx.gis.server.service.geocode.AddressPointSearcher;
+import net.pkhapps.idispatchx.gis.server.service.geocode.GeocodeService;
+import net.pkhapps.idispatchx.gis.server.service.geocode.IntersectionSearcher;
+import net.pkhapps.idispatchx.gis.server.service.geocode.NamedPlaceSearcher;
+import net.pkhapps.idispatchx.gis.server.service.geocode.RoadSegmentSearcher;
 import net.pkhapps.idispatchx.gis.server.service.tile.LayerDiscovery;
 import net.pkhapps.idispatchx.gis.server.service.tile.TileCache;
 import net.pkhapps.idispatchx.gis.server.service.tile.TileResampler;
@@ -92,8 +101,19 @@ public final class GisServer implements AutoCloseable {
                 new TileCache());
         var capGen = new CapabilitiesGenerator(layers);
 
+        // Initialize geocoding services
+        var addressPointRepo = new AddressPointRepository(jooqContextProvider.getDslContext());
+        var roadSegmentRepo = new RoadSegmentRepository(jooqContextProvider.getDslContext());
+        var namedPlaceRepo = new NamedPlaceRepository(jooqContextProvider.getDslContext());
+        var geocodeService = new GeocodeService(
+                new AddressPointSearcher(addressPointRepo),
+                new RoadSegmentSearcher(roadSegmentRepo),
+                new NamedPlaceSearcher(namedPlaceRepo),
+                new IntersectionSearcher(roadSegmentRepo));
+
         // Register routes
         new WmtsController(tileService, capGen).registerRoutes(javalin, jwtAuth, roleAuth);
+        new GeocodeController(geocodeService).registerRoutes(javalin, jwtAuth, roleAuth);
         javalin.post("/api/v1/auth/logout", logoutHandler);
 
         log.info("GIS Server initialized");

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/geocode/GeocodeController.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/geocode/GeocodeController.java
@@ -1,0 +1,68 @@
+package net.pkhapps.idispatchx.gis.server.api.geocode;
+
+import io.javalin.Javalin;
+import io.javalin.http.BadRequestResponse;
+import io.javalin.http.Context;
+import io.javalin.http.Handler;
+import net.pkhapps.idispatchx.gis.server.service.geocode.DatabaseUnavailableException;
+import net.pkhapps.idispatchx.gis.server.service.geocode.GeocodeService;
+
+import java.util.Objects;
+
+/**
+ * Javalin controller for the geocoding API.
+ * <p>
+ * Provides the endpoint:
+ * <ul>
+ *   <li>GET /api/v1/geocode/search – searches for addresses, places, and intersections</li>
+ * </ul>
+ * <p>
+ * All geocoding routes require authentication (applied via before-filters).
+ */
+public final class GeocodeController {
+
+    private final GeocodeService geocodeService;
+
+    /**
+     * Creates a new geocode controller.
+     *
+     * @param geocodeService the geocode service for performing searches
+     */
+    public GeocodeController(GeocodeService geocodeService) {
+        this.geocodeService = Objects.requireNonNull(geocodeService, "geocodeService must not be null");
+    }
+
+    /**
+     * Registers all geocoding routes on the given Javalin instance.
+     *
+     * @param app             the Javalin application
+     * @param jwtAuthHandler  the JWT authentication handler (applied as before-filter)
+     * @param roleAuthHandler the role authorization handler (applied as before-filter)
+     */
+    public void registerRoutes(Javalin app, Handler jwtAuthHandler, Handler roleAuthHandler) {
+        app.before("/api/v1/geocode/*", jwtAuthHandler);
+        app.before("/api/v1/geocode/*", roleAuthHandler);
+        app.get("/api/v1/geocode/search", this::handleSearch);
+    }
+
+    private void handleSearch(Context ctx) {
+        var q = ctx.queryParam("q");
+        var limitStr = ctx.queryParam("limit");
+        var municipality = ctx.queryParam("municipality");
+
+        SearchRequest request;
+        try {
+            request = SearchRequest.of(q, limitStr, municipality);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new BadRequestResponse(e.getMessage());
+        }
+
+        try {
+            var response = geocodeService.search(request);
+            ctx.json(response);
+        } catch (DatabaseUnavailableException e) {
+            ctx.status(503);
+            ctx.json(SearchResponse.empty(request.query()));
+        }
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/geocode/SearchRequest.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/geocode/SearchRequest.java
@@ -65,6 +65,10 @@ public record SearchRequest(
      */
     public SearchRequest {
         Objects.requireNonNull(query, "query must not be null");
+        query = query.trim();
+        if (query.isBlank()) {
+            throw new IllegalArgumentException("query must not be blank");
+        }
         if (query.length() < MIN_QUERY_LENGTH) {
             throw new IllegalArgumentException(
                     "query must be at least " + MIN_QUERY_LENGTH + " characters");

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/AddressPointSearcher.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/AddressPointSearcher.java
@@ -35,4 +35,21 @@ public final class AddressPointSearcher {
                         r.similarityScore()))
                 .toList();
     }
+
+    List<ScoredResult> searchByStreetAndNumber(String streetName, int number, int limit,
+                                                @Nullable MunicipalityCode municipality) {
+        var numberStr = String.valueOf(number);
+        return repository.search(streetName, limit, municipality).stream()
+                .filter(r -> r.municipality() != null)
+                .filter(r -> numberStr.equals(r.number()))
+                .map(r -> new ScoredResult(
+                        new AddressResult(
+                                r.streetName(),
+                                r.number(),
+                                r.municipality(),
+                                r.coordinates(),
+                                AddressSource.ADDRESS_POINT),
+                        r.similarityScore()))
+                .toList();
+    }
 }

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/AddressPointSearcher.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/AddressPointSearcher.java
@@ -1,0 +1,38 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressResult;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressSource;
+import net.pkhapps.idispatchx.gis.server.repository.AddressPointRepository;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Searches address points and maps results to {@link ScoredResult} entries
+ * with {@link AddressSource#ADDRESS_POINT} source.
+ */
+public final class AddressPointSearcher {
+
+    private final AddressPointRepository repository;
+
+    public AddressPointSearcher(AddressPointRepository repository) {
+        this.repository = Objects.requireNonNull(repository, "repository must not be null");
+    }
+
+    List<ScoredResult> search(String query, int limit, @Nullable MunicipalityCode municipality) {
+        return repository.search(query, limit, municipality).stream()
+                .filter(r -> r.municipality() != null)
+                .filter(r -> r.number() != null && !r.number().isBlank())
+                .map(r -> new ScoredResult(
+                        new AddressResult(
+                                r.streetName(),
+                                r.number(),
+                                r.municipality(),
+                                r.coordinates(),
+                                AddressSource.ADDRESS_POINT),
+                        r.similarityScore()))
+                .toList();
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/DatabaseUnavailableException.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/DatabaseUnavailableException.java
@@ -1,0 +1,17 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+/**
+ * Exception thrown when a geocoding operation fails due to database unavailability.
+ */
+public class DatabaseUnavailableException extends RuntimeException {
+
+    /**
+     * Creates a new exception with the given message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the underlying cause
+     */
+    public DatabaseUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/GeocodeService.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/GeocodeService.java
@@ -1,0 +1,131 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.SearchRequest;
+import net.pkhapps.idispatchx.gis.server.api.geocode.SearchResponse;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Orchestrates geocoding by parsing the query, dispatching parallel searches
+ * across multiple data sources using virtual threads, and merging the results.
+ */
+public final class GeocodeService {
+
+    private static final Logger log = LoggerFactory.getLogger(GeocodeService.class);
+
+    private final AddressPointSearcher addressPointSearcher;
+    private final RoadSegmentSearcher roadSegmentSearcher;
+    private final NamedPlaceSearcher namedPlaceSearcher;
+    private final IntersectionSearcher intersectionSearcher;
+    private final QueryParser queryParser = new QueryParser();
+    private final ResultMerger resultMerger = new ResultMerger();
+
+    /**
+     * Creates a new geocode service with the given searchers.
+     *
+     * @param addressPointSearcher  the address point searcher
+     * @param roadSegmentSearcher   the road segment searcher
+     * @param namedPlaceSearcher    the named place searcher
+     * @param intersectionSearcher  the intersection searcher
+     */
+    public GeocodeService(AddressPointSearcher addressPointSearcher,
+                          RoadSegmentSearcher roadSegmentSearcher,
+                          NamedPlaceSearcher namedPlaceSearcher,
+                          IntersectionSearcher intersectionSearcher) {
+        this.addressPointSearcher = Objects.requireNonNull(addressPointSearcher);
+        this.roadSegmentSearcher = Objects.requireNonNull(roadSegmentSearcher);
+        this.namedPlaceSearcher = Objects.requireNonNull(namedPlaceSearcher);
+        this.intersectionSearcher = Objects.requireNonNull(intersectionSearcher);
+    }
+
+    /**
+     * Performs a geocoding search based on the given request.
+     *
+     * @param request the search request
+     * @return the search response with merged results
+     * @throws DatabaseUnavailableException if database access fails
+     */
+    public SearchResponse search(SearchRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+
+        var query = request.query();
+        var limit = request.limit();
+        @Nullable MunicipalityCode municipality = request.municipalityCode();
+
+        var parsedQuery = queryParser.parse(query);
+        log.info("Geocode search: queryLength={}, limit={}, municipality={}, parsedType={}",
+                query.length(), limit, municipality, parsedQuery.getClass().getSimpleName());
+
+        try {
+            var searchTasks = dispatchSearches(parsedQuery, limit, municipality);
+            var allResults = collectResults(searchTasks);
+            var merged = resultMerger.merge(allResults, limit);
+
+            log.info("Geocode search completed: resultCount={}", merged.size());
+            return SearchResponse.of(merged, query);
+        } catch (RuntimeException e) {
+            throw new DatabaseUnavailableException("Geocoding search failed", e);
+        }
+    }
+
+    private List<Future<List<ScoredResult>>> dispatchSearches(ParsedQuery parsedQuery, int limit,
+                                                               @Nullable MunicipalityCode municipality) {
+        var futures = new ArrayList<Future<List<ScoredResult>>>();
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            switch (parsedQuery) {
+                case ParsedQuery.AddressQuery aq -> {
+                    futures.add(executor.submit(() ->
+                            addressPointSearcher.search(aq.streetName(), limit, municipality)));
+                    futures.add(executor.submit(() ->
+                            roadSegmentSearcher.searchAddress(aq.streetName(), aq.number(), municipality)));
+                }
+                case ParsedQuery.StreetQuery sq -> {
+                    futures.add(executor.submit(() ->
+                            addressPointSearcher.search(sq.name(), limit, municipality)));
+                    futures.add(executor.submit(() ->
+                            namedPlaceSearcher.search(sq.name(), limit, municipality)));
+                }
+                case ParsedQuery.IntersectionQuery iq -> {
+                    futures.add(executor.submit(() ->
+                            intersectionSearcher.search(iq.roadA(), limit, municipality)));
+                    futures.add(executor.submit(() ->
+                            intersectionSearcher.search(iq.roadB(), limit, municipality)));
+                }
+                case ParsedQuery.PlaceQuery pq -> {
+                    futures.add(executor.submit(() ->
+                            namedPlaceSearcher.search(pq.name(), limit, municipality)));
+                    futures.add(executor.submit(() ->
+                            addressPointSearcher.search(pq.name(), limit, municipality)));
+                }
+            }
+        }
+        // The try-with-resources will wait for all tasks to complete
+
+        return futures;
+    }
+
+    private List<ScoredResult> collectResults(List<Future<List<ScoredResult>>> futures) {
+        var allResults = new ArrayList<ScoredResult>();
+        for (var future : futures) {
+            try {
+                allResults.addAll(future.get());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Search interrupted", e);
+            } catch (ExecutionException e) {
+                throw new RuntimeException("Search task failed", e.getCause());
+            }
+        }
+        return allResults;
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/GeocodeService.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/GeocodeService.java
@@ -85,7 +85,8 @@ public final class GeocodeService {
             switch (parsedQuery) {
                 case ParsedQuery.AddressQuery aq -> {
                     futures.add(executor.submit(() ->
-                            addressPointSearcher.search(aq.streetName(), limit, municipality)));
+                            addressPointSearcher.searchByStreetAndNumber(
+                                    aq.streetName(), aq.number(), limit, municipality)));
                     futures.add(executor.submit(() ->
                             roadSegmentSearcher.searchAddress(aq.streetName(), aq.number(), municipality)));
                 }
@@ -97,9 +98,9 @@ public final class GeocodeService {
                 }
                 case ParsedQuery.IntersectionQuery iq -> {
                     futures.add(executor.submit(() ->
-                            intersectionSearcher.search(iq.roadA(), limit, municipality)));
+                            intersectionSearcher.searchPair(iq.roadA(), iq.roadB(), limit, municipality)));
                     futures.add(executor.submit(() ->
-                            intersectionSearcher.search(iq.roadB(), limit, municipality)));
+                            intersectionSearcher.searchPair(iq.roadB(), iq.roadA(), limit, municipality)));
                 }
                 case ParsedQuery.PlaceQuery pq -> {
                     futures.add(executor.submit(() ->

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/IntersectionSearcher.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/IntersectionSearcher.java
@@ -1,0 +1,35 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.IntersectionResult;
+import net.pkhapps.idispatchx.gis.server.repository.RoadSegmentRepository;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Searches road intersections and maps results to {@link ScoredResult} entries.
+ */
+public final class IntersectionSearcher {
+
+    private final RoadSegmentRepository repository;
+
+    public IntersectionSearcher(RoadSegmentRepository repository) {
+        this.repository = Objects.requireNonNull(repository, "repository must not be null");
+    }
+
+    List<ScoredResult> search(String query, int limit, @Nullable MunicipalityCode municipality) {
+        return repository.searchIntersections(query, limit, municipality).stream()
+                .filter(r -> r.municipality() != null)
+                .filter(r -> !r.roadA().isEmpty() && !r.roadB().isEmpty())
+                .map(r -> new ScoredResult(
+                        new IntersectionResult(
+                                r.roadA(),
+                                r.roadB(),
+                                r.municipality(),
+                                r.coordinates()),
+                        r.similarityScore()))
+                .toList();
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/IntersectionSearcher.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/IntersectionSearcher.java
@@ -1,7 +1,9 @@
 package net.pkhapps.idispatchx.gis.server.service.geocode;
 
+import net.pkhapps.idispatchx.common.domain.model.MultilingualName;
 import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
 import net.pkhapps.idispatchx.gis.server.api.geocode.IntersectionResult;
+import net.pkhapps.idispatchx.gis.server.repository.IntersectionSearchResult;
 import net.pkhapps.idispatchx.gis.server.repository.RoadSegmentRepository;
 import org.jspecify.annotations.Nullable;
 
@@ -31,5 +33,26 @@ public final class IntersectionSearcher {
                                 r.coordinates()),
                         r.similarityScore()))
                 .toList();
+    }
+
+    List<ScoredResult> searchPair(String roadA, String roadB, int limit,
+                                   @Nullable MunicipalityCode municipality) {
+        return repository.searchIntersections(roadA, limit, municipality).stream()
+                .filter(r -> r.municipality() != null)
+                .filter(r -> !r.roadA().isEmpty() && !r.roadB().isEmpty())
+                .filter(r -> nameMatchesAny(r.roadA(), roadB) || nameMatchesAny(r.roadB(), roadB))
+                .map(r -> new ScoredResult(
+                        new IntersectionResult(
+                                r.roadA(),
+                                r.roadB(),
+                                r.municipality(),
+                                r.coordinates()),
+                        r.similarityScore()))
+                .toList();
+    }
+
+    private boolean nameMatchesAny(MultilingualName name, String query) {
+        return name.values().values().stream()
+                .anyMatch(v -> v.toLowerCase().contains(query.toLowerCase()));
     }
 }

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/NamedPlaceSearcher.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/NamedPlaceSearcher.java
@@ -1,0 +1,35 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.PlaceResult;
+import net.pkhapps.idispatchx.gis.server.repository.NamedPlaceRepository;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Searches named places and maps results to {@link ScoredResult} entries.
+ */
+public final class NamedPlaceSearcher {
+
+    private final NamedPlaceRepository repository;
+
+    public NamedPlaceSearcher(NamedPlaceRepository repository) {
+        this.repository = Objects.requireNonNull(repository, "repository must not be null");
+    }
+
+    List<ScoredResult> search(String query, int limit, @Nullable MunicipalityCode municipality) {
+        return repository.search(query, limit, municipality).stream()
+                .filter(r -> r.municipality() != null)
+                .filter(r -> !r.name().isEmpty())
+                .map(r -> new ScoredResult(
+                        new PlaceResult(
+                                r.name(),
+                                r.placeClass(),
+                                r.municipality(),
+                                r.coordinates()),
+                        r.similarityScore()))
+                .toList();
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/ParsedQuery.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/ParsedQuery.java
@@ -1,0 +1,83 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import java.util.Objects;
+
+/**
+ * A sealed interface representing a parsed geocoding query.
+ * <p>
+ * The query parser analyzes a raw search string and classifies it into one of
+ * four query types: address, street, intersection, or place.
+ *
+ * @see QueryParser
+ */
+sealed interface ParsedQuery permits
+        ParsedQuery.AddressQuery,
+        ParsedQuery.StreetQuery,
+        ParsedQuery.IntersectionQuery,
+        ParsedQuery.PlaceQuery {
+
+    /**
+     * A query for a specific street address (e.g., "Mannerheimintie 5").
+     *
+     * @param streetName the street name (non-blank)
+     * @param number     the address number (must be at least 1)
+     */
+    record AddressQuery(String streetName, int number) implements ParsedQuery {
+        public AddressQuery {
+            Objects.requireNonNull(streetName, "streetName must not be null");
+            if (streetName.isBlank()) {
+                throw new IllegalArgumentException("streetName must not be blank");
+            }
+            if (number < 1) {
+                throw new IllegalArgumentException("number must be at least 1, got " + number);
+            }
+        }
+    }
+
+    /**
+     * A query for a street by name without a specific number (e.g., "Mannerheimintie").
+     *
+     * @param name the street name (non-blank)
+     */
+    record StreetQuery(String name) implements ParsedQuery {
+        public StreetQuery {
+            Objects.requireNonNull(name, "name must not be null");
+            if (name.isBlank()) {
+                throw new IllegalArgumentException("name must not be blank");
+            }
+        }
+    }
+
+    /**
+     * A query for a road intersection (e.g., "Mannerheimintie / Aleksanterinkatu").
+     *
+     * @param roadA the first road name (non-blank)
+     * @param roadB the second road name (non-blank)
+     */
+    record IntersectionQuery(String roadA, String roadB) implements ParsedQuery {
+        public IntersectionQuery {
+            Objects.requireNonNull(roadA, "roadA must not be null");
+            Objects.requireNonNull(roadB, "roadB must not be null");
+            if (roadA.isBlank()) {
+                throw new IllegalArgumentException("roadA must not be blank");
+            }
+            if (roadB.isBlank()) {
+                throw new IllegalArgumentException("roadB must not be blank");
+            }
+        }
+    }
+
+    /**
+     * A query for a named place (e.g., "Helsinki").
+     *
+     * @param name the place name (non-blank)
+     */
+    record PlaceQuery(String name) implements ParsedQuery {
+        public PlaceQuery {
+            Objects.requireNonNull(name, "name must not be null");
+            if (name.isBlank()) {
+                throw new IllegalArgumentException("name must not be blank");
+            }
+        }
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/QueryParser.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/QueryParser.java
@@ -1,0 +1,74 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Stateless parser that classifies a raw search string into a {@link ParsedQuery} variant.
+ * <p>
+ * Detection order:
+ * <ol>
+ *   <li><strong>Intersection</strong> — contains a separator ({@code /}, {@code &}, or the words
+ *       {@code and}, {@code ja}, {@code och}) with letter-containing parts on both sides</li>
+ *   <li><strong>Address</strong> — ends with a number, preceded by a non-blank street name</li>
+ *   <li><strong>Street</strong> — contains whitespace (multiple words)</li>
+ *   <li><strong>Place</strong> — fallback for single-word queries</li>
+ * </ol>
+ */
+final class QueryParser {
+
+    private static final Pattern INTERSECTION_SEPARATOR =
+            Pattern.compile("\\s*/\\s*|\\s*&\\s*|\\s+(?:and|ja|och)\\s+", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern ADDRESS_PATTERN =
+            Pattern.compile("^(.+?)\\s+(\\d+)\\s*$");
+
+    private static final Pattern CONTAINS_LETTER =
+            Pattern.compile("[a-zA-ZåäöÅÄÖ]");
+
+    /**
+     * Parses a raw search query into a typed {@link ParsedQuery}.
+     *
+     * @param query the raw search string (must not be null or blank)
+     * @return the parsed query
+     * @throws NullPointerException     if query is null
+     * @throws IllegalArgumentException if query is blank
+     */
+    ParsedQuery parse(String query) {
+        Objects.requireNonNull(query, "query must not be null");
+        var trimmed = query.trim();
+        if (trimmed.isBlank()) {
+            throw new IllegalArgumentException("query must not be blank");
+        }
+
+        // 1. Intersection detection
+        var parts = INTERSECTION_SEPARATOR.split(trimmed, -1);
+        if (parts.length == 2) {
+            var roadA = parts[0].trim();
+            var roadB = parts[1].trim();
+            if (!roadA.isBlank() && !roadB.isBlank()
+                    && CONTAINS_LETTER.matcher(roadA).find()
+                    && CONTAINS_LETTER.matcher(roadB).find()) {
+                return new ParsedQuery.IntersectionQuery(roadA, roadB);
+            }
+        }
+
+        // 2. Address detection
+        var addressMatcher = ADDRESS_PATTERN.matcher(trimmed);
+        if (addressMatcher.matches()) {
+            var streetName = addressMatcher.group(1).replaceAll("[/&]+$", "").trim();
+            var number = Integer.parseInt(addressMatcher.group(2));
+            if (!streetName.isBlank() && number >= 1) {
+                return new ParsedQuery.AddressQuery(streetName, number);
+            }
+        }
+
+        // 3. Street detection (multiple words)
+        if (trimmed.contains(" ")) {
+            return new ParsedQuery.StreetQuery(trimmed);
+        }
+
+        // 4. Fallback to place
+        return new ParsedQuery.PlaceQuery(trimmed);
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/ResultMerger.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/ResultMerger.java
@@ -1,0 +1,96 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressResult;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressSource;
+import net.pkhapps.idispatchx.gis.server.api.geocode.LocationResult;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Merges, deduplicates, and limits scored geocoding results.
+ * <p>
+ * Deduplication rules:
+ * <ul>
+ *   <li>Address results with the same street name and number are deduplicated,
+ *       preferring {@link AddressSource#ADDRESS_POINT} over {@link AddressSource#ROAD_SEGMENT}</li>
+ *   <li>Results of the same type with coordinates within ~10 m (0.0001 degrees)
+ *       are considered duplicates</li>
+ * </ul>
+ */
+final class ResultMerger {
+
+    private static final double PROXIMITY_THRESHOLD = 0.0001;
+
+    List<LocationResult> merge(List<ScoredResult> results, int limit) {
+        var sorted = results.stream()
+                .sorted(Comparator.comparingDouble(ScoredResult::score).reversed())
+                .toList();
+
+        var accepted = new ArrayList<LocationResult>();
+
+        for (var candidate : sorted) {
+            if (accepted.size() >= limit) {
+                break;
+            }
+
+            var result = candidate.result();
+
+            if (result instanceof AddressResult candidateAddr) {
+                if (isDuplicateAddress(accepted, candidateAddr)) {
+                    continue;
+                }
+            }
+
+            if (isProximityDuplicate(accepted, result)) {
+                continue;
+            }
+
+            accepted.add(result);
+        }
+
+        return List.copyOf(accepted);
+    }
+
+    private boolean isDuplicateAddress(List<LocationResult> accepted, AddressResult candidate) {
+        for (var existing : accepted) {
+            if (existing instanceof AddressResult existingAddr) {
+                if (sameStreetAndNumber(existingAddr, candidate)) {
+                    // If the existing one is ADDRESS_POINT, skip the candidate
+                    if (existingAddr.source() == AddressSource.ADDRESS_POINT) {
+                        return true;
+                    }
+                    // If the candidate is ADDRESS_POINT and existing is ROAD_SEGMENT, replace
+                    if (candidate.source() == AddressSource.ADDRESS_POINT
+                            && existingAddr.source() == AddressSource.ROAD_SEGMENT) {
+                        accepted.set(accepted.indexOf(existingAddr), candidate);
+                        return true;
+                    }
+                    // Same source, skip duplicate
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean sameStreetAndNumber(AddressResult a, AddressResult b) {
+        var nameA = a.name().anyValue().orElse("");
+        var nameB = b.name().anyValue().orElse("");
+        return nameA.equalsIgnoreCase(nameB) && a.number().equals(b.number());
+    }
+
+    private boolean isProximityDuplicate(List<LocationResult> accepted, LocationResult candidate) {
+        for (var existing : accepted) {
+            if (existing.getClass() == candidate.getClass()) {
+                var dx = Math.abs(existing.coordinates().longitude() - candidate.coordinates().longitude());
+                var dy = Math.abs(existing.coordinates().latitude() - candidate.coordinates().latitude());
+                if (dx < PROXIMITY_THRESHOLD && dy < PROXIMITY_THRESHOLD) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/RoadSegmentSearcher.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/RoadSegmentSearcher.java
@@ -1,0 +1,42 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressResult;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressSource;
+import net.pkhapps.idispatchx.gis.server.repository.RoadSegmentRepository;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Searches for addresses by interpolating along road segments.
+ * <p>
+ * Results are assigned a fixed score of 0.9 — high, but below exact address point
+ * matches — so that address points take priority during result merging.
+ */
+public final class RoadSegmentSearcher {
+
+    private static final double INTERPOLATED_SCORE = 0.9;
+
+    private final RoadSegmentRepository repository;
+
+    public RoadSegmentSearcher(RoadSegmentRepository repository) {
+        this.repository = Objects.requireNonNull(repository, "repository must not be null");
+    }
+
+    List<ScoredResult> searchAddress(String streetName, int number, @Nullable MunicipalityCode municipality) {
+        return repository.interpolateAddress(streetName, number, municipality)
+                .filter(r -> r.municipality() != null)
+                .map(r -> new ScoredResult(
+                        new AddressResult(
+                                r.streetName(),
+                                r.number(),
+                                r.municipality(),
+                                r.coordinates(),
+                                AddressSource.ROAD_SEGMENT),
+                        INTERPOLATED_SCORE))
+                .map(List::of)
+                .orElse(List.of());
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/ScoredResult.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/ScoredResult.java
@@ -1,0 +1,18 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.gis.server.api.geocode.LocationResult;
+
+import java.util.Objects;
+
+/**
+ * A location result paired with a relevance score for ranking during result merging.
+ *
+ * @param result the location result
+ * @param score  the relevance score (0.0 to 1.0, higher is better)
+ */
+record ScoredResult(LocationResult result, double score) {
+
+    ScoredResult {
+        Objects.requireNonNull(result, "result must not be null");
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/package-info.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/geocode/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Geocoding service layer for parsing search queries and searching across multiple data sources.
+ */
+@NullMarked
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import org.jspecify.annotations.NullMarked;

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/geocode/GeocodeControllerTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/geocode/GeocodeControllerTest.java
@@ -1,0 +1,125 @@
+package net.pkhapps.idispatchx.gis.server.api.geocode;
+
+import io.javalin.http.BadRequestResponse;
+import io.javalin.http.Context;
+import net.pkhapps.idispatchx.common.domain.model.Coordinates;
+import net.pkhapps.idispatchx.common.domain.model.MultilingualName;
+import net.pkhapps.idispatchx.common.domain.model.Municipality;
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.service.geocode.DatabaseUnavailableException;
+import net.pkhapps.idispatchx.gis.server.service.geocode.GeocodeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GeocodeControllerTest {
+
+    @Mock
+    private GeocodeService geocodeService;
+
+    @Mock
+    private Context ctx;
+
+    private GeocodeController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new GeocodeController(geocodeService);
+    }
+
+    // ==================== Successful search ====================
+
+    @Test
+    void handleSearch_validRequest_returnsJsonResponse() throws Exception {
+        when(ctx.queryParam("q")).thenReturn("Mannerheimintie 5");
+        when(ctx.queryParam("limit")).thenReturn("10");
+        when(ctx.queryParam("municipality")).thenReturn(null);
+
+        var response = SearchResponse.of(List.of(
+                new AddressResult(
+                        MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null),
+                        "5",
+                        Municipality.of(MunicipalityCode.of("091"),
+                                MultilingualName.ofFinnishFields("Helsinki", null, null, null, null)),
+                        Coordinates.Epsg4326.of(60.17, 24.93),
+                        AddressSource.ADDRESS_POINT)
+        ), "Mannerheimintie 5");
+
+        when(geocodeService.search(any(SearchRequest.class))).thenReturn(response);
+
+        invokeHandleSearch();
+
+        verify(ctx).json(response);
+    }
+
+    // ==================== Validation errors ====================
+
+    @Test
+    void handleSearch_nullQuery_throws400() {
+        when(ctx.queryParam("q")).thenReturn(null);
+        when(ctx.queryParam("limit")).thenReturn(null);
+        when(ctx.queryParam("municipality")).thenReturn(null);
+
+        assertThrows(BadRequestResponse.class, this::invokeHandleSearch);
+    }
+
+    @Test
+    void handleSearch_queryTooShort_throws400() {
+        when(ctx.queryParam("q")).thenReturn("ab");
+        when(ctx.queryParam("limit")).thenReturn(null);
+        when(ctx.queryParam("municipality")).thenReturn(null);
+
+        assertThrows(BadRequestResponse.class, this::invokeHandleSearch);
+    }
+
+    @Test
+    void handleSearch_invalidLimit_throws400() {
+        when(ctx.queryParam("q")).thenReturn("Helsinki");
+        when(ctx.queryParam("limit")).thenReturn("abc");
+        when(ctx.queryParam("municipality")).thenReturn(null);
+
+        assertThrows(BadRequestResponse.class, this::invokeHandleSearch);
+    }
+
+    // ==================== Database unavailable ====================
+
+    @Test
+    void handleSearch_databaseUnavailable_returns503() throws Exception {
+        when(ctx.queryParam("q")).thenReturn("Helsinki");
+        when(ctx.queryParam("limit")).thenReturn(null);
+        when(ctx.queryParam("municipality")).thenReturn(null);
+
+        when(geocodeService.search(any(SearchRequest.class)))
+                .thenThrow(new DatabaseUnavailableException("DB down", new RuntimeException()));
+
+        invokeHandleSearch();
+
+        verify(ctx).status(503);
+        verify(ctx).json(any(SearchResponse.class));
+    }
+
+    // ==================== helpers ====================
+
+    private void invokeHandleSearch() throws Exception {
+        var method = GeocodeController.class.getDeclaredMethod("handleSearch", Context.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(controller, ctx);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            var cause = e.getCause();
+            if (cause instanceof RuntimeException re) {
+                throw re;
+            }
+            throw e;
+        }
+    }
+}

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/geocode/SearchRequestTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/geocode/SearchRequestTest.java
@@ -88,6 +88,18 @@ class SearchRequestTest {
     }
 
     @Test
+    void constructor_whitespaceOnlyQuery_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new SearchRequest("   ", 20, null));
+    }
+
+    @Test
+    void constructor_queryWithSurroundingSpaces_trims() {
+        var request = new SearchRequest("  test query  ", 20, null);
+        assertEquals("test query", request.query());
+    }
+
+    @Test
     void constructor_queryExactlyMinLength_createsInstance() {
         var request = new SearchRequest("abc", 20, null);
         assertEquals("abc", request.query());

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/AddressPointSearcherTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/AddressPointSearcherTest.java
@@ -1,0 +1,101 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.Coordinates;
+import net.pkhapps.idispatchx.common.domain.model.MultilingualName;
+import net.pkhapps.idispatchx.common.domain.model.Municipality;
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressResult;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressSource;
+import net.pkhapps.idispatchx.gis.server.repository.AddressPointRepository;
+import net.pkhapps.idispatchx.gis.server.repository.AddressSearchResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddressPointSearcherTest {
+
+    @Mock
+    private AddressPointRepository repository;
+
+    private static final MunicipalityCode MUNI_CODE = MunicipalityCode.of("091");
+    private static final Municipality MUNICIPALITY = Municipality.of(
+            MUNI_CODE, MultilingualName.ofFinnishFields("Helsinki", "Helsingfors", null, null, null));
+    private static final Coordinates.Epsg4326 COORDS = Coordinates.Epsg4326.of(60.1699, 24.9384);
+
+    @Test
+    void search_validResults_mapsToAddressResults() {
+        var searcher = new AddressPointSearcher(repository);
+        var searchResult = new AddressSearchResult(
+                1L, "5", MultilingualName.ofFinnishFields("Mannerheimintie", "Mannerheimvägen", null, null, null),
+                MUNICIPALITY, COORDS, 0.85);
+
+        when(repository.search("Mannerheimintie", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("Mannerheimintie", 10, null);
+
+        assertEquals(1, results.size());
+        var scored = results.getFirst();
+        assertEquals(0.85, scored.score());
+        assertInstanceOf(AddressResult.class, scored.result());
+
+        var addr = (AddressResult) scored.result();
+        assertEquals("5", addr.number());
+        assertEquals(AddressSource.ADDRESS_POINT, addr.source());
+        assertEquals(MUNICIPALITY, addr.municipality());
+    }
+
+    @Test
+    void search_nullMunicipality_filtered() {
+        var searcher = new AddressPointSearcher(repository);
+        var searchResult = new AddressSearchResult(
+                1L, "5", MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null),
+                null, COORDS, 0.85);
+
+        when(repository.search("Mannerheimintie", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("Mannerheimintie", 10, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void search_nullNumber_filtered() {
+        var searcher = new AddressPointSearcher(repository);
+        var searchResult = new AddressSearchResult(
+                1L, null, MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null),
+                MUNICIPALITY, COORDS, 0.85);
+
+        when(repository.search("Mannerheimintie", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("Mannerheimintie", 10, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void search_blankNumber_filtered() {
+        var searcher = new AddressPointSearcher(repository);
+        var searchResult = new AddressSearchResult(
+                1L, "  ", MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null),
+                MUNICIPALITY, COORDS, 0.85);
+
+        when(repository.search("Mannerheimintie", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("Mannerheimintie", 10, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void search_emptyRepositoryResult_returnsEmptyList() {
+        var searcher = new AddressPointSearcher(repository);
+        when(repository.search("nothing", 10, null)).thenReturn(List.of());
+
+        var results = searcher.search("nothing", 10, null);
+        assertTrue(results.isEmpty());
+    }
+}

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/AddressPointSearcherTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/AddressPointSearcherTest.java
@@ -98,4 +98,50 @@ class AddressPointSearcherTest {
         var results = searcher.search("nothing", 10, null);
         assertTrue(results.isEmpty());
     }
+
+    // ==================== searchByStreetAndNumber ====================
+
+    @Test
+    void searchByStreetAndNumber_matchingNumber_returnsResult() {
+        var searcher = new AddressPointSearcher(repository);
+        var match = new AddressSearchResult(
+                1L, "5", MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null),
+                MUNICIPALITY, COORDS, 0.85);
+        var other = new AddressSearchResult(
+                2L, "7", MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null),
+                MUNICIPALITY, Coordinates.Epsg4326.of(60.18, 24.94), 0.83);
+
+        when(repository.search("Mannerheimintie", 10, null)).thenReturn(List.of(match, other));
+
+        var results = searcher.searchByStreetAndNumber("Mannerheimintie", 5, 10, null);
+
+        assertEquals(1, results.size());
+        assertEquals("5", ((AddressResult) results.getFirst().result()).number());
+    }
+
+    @Test
+    void searchByStreetAndNumber_noMatchingNumber_returnsEmpty() {
+        var searcher = new AddressPointSearcher(repository);
+        var other = new AddressSearchResult(
+                1L, "7", MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null),
+                MUNICIPALITY, COORDS, 0.85);
+
+        when(repository.search("Mannerheimintie", 10, null)).thenReturn(List.of(other));
+
+        var results = searcher.searchByStreetAndNumber("Mannerheimintie", 5, 10, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void searchByStreetAndNumber_nullMunicipality_filtered() {
+        var searcher = new AddressPointSearcher(repository);
+        var match = new AddressSearchResult(
+                1L, "5", MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null),
+                null, COORDS, 0.85);
+
+        when(repository.search("Mannerheimintie", 10, null)).thenReturn(List.of(match));
+
+        var results = searcher.searchByStreetAndNumber("Mannerheimintie", 5, 10, null);
+        assertTrue(results.isEmpty());
+    }
 }

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/IntersectionSearcherTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/IntersectionSearcherTest.java
@@ -1,0 +1,86 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.Coordinates;
+import net.pkhapps.idispatchx.common.domain.model.MultilingualName;
+import net.pkhapps.idispatchx.common.domain.model.Municipality;
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.IntersectionResult;
+import net.pkhapps.idispatchx.gis.server.repository.IntersectionSearchResult;
+import net.pkhapps.idispatchx.gis.server.repository.RoadSegmentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IntersectionSearcherTest {
+
+    @Mock
+    private RoadSegmentRepository repository;
+
+    private static final MunicipalityCode MUNI_CODE = MunicipalityCode.of("091");
+    private static final Municipality MUNICIPALITY = Municipality.of(
+            MUNI_CODE, MultilingualName.ofFinnishFields("Helsinki", "Helsingfors", null, null, null));
+    private static final Coordinates.Epsg4326 COORDS = Coordinates.Epsg4326.of(60.1699, 24.9384);
+
+    @Test
+    void search_validResults_mapsToIntersectionResults() {
+        var searcher = new IntersectionSearcher(repository);
+        var roadA = MultilingualName.ofFinnishFields("Mannerheimintie", "Mannerheimvägen", null, null, null);
+        var roadB = MultilingualName.ofFinnishFields("Aleksanterinkatu", "Alexandersgatan", null, null, null);
+        var searchResult = new IntersectionSearchResult(roadA, roadB, MUNICIPALITY, COORDS, 0.80);
+
+        when(repository.searchIntersections("Mannerheimintie", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("Mannerheimintie", 10, null);
+
+        assertEquals(1, results.size());
+        var scored = results.getFirst();
+        assertEquals(0.80, scored.score());
+        assertInstanceOf(IntersectionResult.class, scored.result());
+
+        var intersection = (IntersectionResult) scored.result();
+        assertEquals(roadA, intersection.roadA());
+        assertEquals(roadB, intersection.roadB());
+    }
+
+    @Test
+    void search_nullMunicipality_filtered() {
+        var searcher = new IntersectionSearcher(repository);
+        var roadA = MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null);
+        var roadB = MultilingualName.ofFinnishFields("Aleksanterinkatu", null, null, null, null);
+        var searchResult = new IntersectionSearchResult(roadA, roadB, null, COORDS, 0.80);
+
+        when(repository.searchIntersections("Mannerheimintie", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("Mannerheimintie", 10, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void search_emptyRoadName_filtered() {
+        var searcher = new IntersectionSearcher(repository);
+        var roadA = MultilingualName.empty();
+        var roadB = MultilingualName.ofFinnishFields("Aleksanterinkatu", null, null, null, null);
+        var searchResult = new IntersectionSearchResult(roadA, roadB, MUNICIPALITY, COORDS, 0.80);
+
+        when(repository.searchIntersections("test", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("test", 10, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void search_emptyRepositoryResult_returnsEmptyList() {
+        var searcher = new IntersectionSearcher(repository);
+        when(repository.searchIntersections("nothing", 10, null)).thenReturn(List.of());
+
+        var results = searcher.search("nothing", 10, null);
+        assertTrue(results.isEmpty());
+    }
+}

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/IntersectionSearcherTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/IntersectionSearcherTest.java
@@ -83,4 +83,43 @@ class IntersectionSearcherTest {
         var results = searcher.search("nothing", 10, null);
         assertTrue(results.isEmpty());
     }
+
+    // ==================== searchPair ====================
+
+    @Test
+    void searchPair_matchingPair_returnsResult() {
+        var searcher = new IntersectionSearcher(repository);
+        var roadA = MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null);
+        var roadB = MultilingualName.ofFinnishFields("Aleksanterinkatu", null, null, null, null);
+        var match = new IntersectionSearchResult(roadA, roadB, MUNICIPALITY, COORDS, 0.80);
+
+        // Also include an unrelated intersection that should be filtered out
+        var roadC = MultilingualName.ofFinnishFields("Kaivokatu", null, null, null, null);
+        var unrelated = new IntersectionSearchResult(roadA, roadC, MUNICIPALITY,
+                Coordinates.Epsg4326.of(60.18, 24.94), 0.75);
+
+        when(repository.searchIntersections("Mannerheimintie", 10, null))
+                .thenReturn(List.of(match, unrelated));
+
+        var results = searcher.searchPair("Mannerheimintie", "Aleksanterinkatu", 10, null);
+
+        assertEquals(1, results.size());
+        var intersection = (IntersectionResult) results.getFirst().result();
+        assertEquals(roadA, intersection.roadA());
+        assertEquals(roadB, intersection.roadB());
+    }
+
+    @Test
+    void searchPair_noMatchForOtherRoad_returnsEmpty() {
+        var searcher = new IntersectionSearcher(repository);
+        var roadA = MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null);
+        var roadC = MultilingualName.ofFinnishFields("Kaivokatu", null, null, null, null);
+        var unrelated = new IntersectionSearchResult(roadA, roadC, MUNICIPALITY, COORDS, 0.80);
+
+        when(repository.searchIntersections("Mannerheimintie", 10, null))
+                .thenReturn(List.of(unrelated));
+
+        var results = searcher.searchPair("Mannerheimintie", "Aleksanterinkatu", 10, null);
+        assertTrue(results.isEmpty());
+    }
 }

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/NamedPlaceSearcherTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/NamedPlaceSearcherTest.java
@@ -1,0 +1,89 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.Coordinates;
+import net.pkhapps.idispatchx.common.domain.model.MultilingualName;
+import net.pkhapps.idispatchx.common.domain.model.Municipality;
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.PlaceResult;
+import net.pkhapps.idispatchx.gis.server.repository.NamedPlaceRepository;
+import net.pkhapps.idispatchx.gis.server.repository.NamedPlaceSearchResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NamedPlaceSearcherTest {
+
+    @Mock
+    private NamedPlaceRepository repository;
+
+    private static final MunicipalityCode MUNI_CODE = MunicipalityCode.of("091");
+    private static final Municipality MUNICIPALITY = Municipality.of(
+            MUNI_CODE, MultilingualName.ofFinnishFields("Helsinki", "Helsingfors", null, null, null));
+    private static final Coordinates.Epsg4326 COORDS = Coordinates.Epsg4326.of(60.1699, 24.9384);
+
+    @Test
+    void search_validResults_mapsToPlaceResults() {
+        var searcher = new NamedPlaceSearcher(repository);
+        var searchResult = new NamedPlaceSearchResult(
+                100L,
+                MultilingualName.ofFinnishFields("Senaatintori", "Senatstorget", null, null, null),
+                48111, MUNICIPALITY, COORDS, 0.75);
+
+        when(repository.search("Senaatintori", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("Senaatintori", 10, null);
+
+        assertEquals(1, results.size());
+        var scored = results.getFirst();
+        assertEquals(0.75, scored.score());
+        assertInstanceOf(PlaceResult.class, scored.result());
+
+        var place = (PlaceResult) scored.result();
+        assertEquals(48111, place.placeClass());
+        assertEquals(MUNICIPALITY, place.municipality());
+    }
+
+    @Test
+    void search_nullMunicipality_filtered() {
+        var searcher = new NamedPlaceSearcher(repository);
+        var searchResult = new NamedPlaceSearchResult(
+                100L,
+                MultilingualName.ofFinnishFields("Senaatintori", null, null, null, null),
+                48111, null, COORDS, 0.75);
+
+        when(repository.search("Senaatintori", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("Senaatintori", 10, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void search_emptyName_filtered() {
+        var searcher = new NamedPlaceSearcher(repository);
+        var searchResult = new NamedPlaceSearchResult(
+                100L,
+                MultilingualName.empty(),
+                48111, MUNICIPALITY, COORDS, 0.75);
+
+        when(repository.search("test", 10, null)).thenReturn(List.of(searchResult));
+
+        var results = searcher.search("test", 10, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void search_emptyRepositoryResult_returnsEmptyList() {
+        var searcher = new NamedPlaceSearcher(repository);
+        when(repository.search("nothing", 10, null)).thenReturn(List.of());
+
+        var results = searcher.search("nothing", 10, null);
+        assertTrue(results.isEmpty());
+    }
+}

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/ParsedQueryTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/ParsedQueryTest.java
@@ -1,0 +1,102 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParsedQueryTest {
+
+    // ==================== AddressQuery ====================
+
+    @Test
+    void addressQuery_validInput_createsInstance() {
+        var query = new ParsedQuery.AddressQuery("Mannerheimintie", 5);
+        assertEquals("Mannerheimintie", query.streetName());
+        assertEquals(5, query.number());
+    }
+
+    @Test
+    void addressQuery_nullStreetName_throwsNpe() {
+        assertThrows(NullPointerException.class, () -> new ParsedQuery.AddressQuery(null, 5));
+    }
+
+    @Test
+    void addressQuery_blankStreetName_throwsIae() {
+        assertThrows(IllegalArgumentException.class, () -> new ParsedQuery.AddressQuery("  ", 5));
+    }
+
+    @Test
+    void addressQuery_zeroNumber_throwsIae() {
+        assertThrows(IllegalArgumentException.class, () -> new ParsedQuery.AddressQuery("Mannerheimintie", 0));
+    }
+
+    @Test
+    void addressQuery_negativeNumber_throwsIae() {
+        assertThrows(IllegalArgumentException.class, () -> new ParsedQuery.AddressQuery("Mannerheimintie", -1));
+    }
+
+    // ==================== StreetQuery ====================
+
+    @Test
+    void streetQuery_validInput_createsInstance() {
+        var query = new ParsedQuery.StreetQuery("Mannerheimintie");
+        assertEquals("Mannerheimintie", query.name());
+    }
+
+    @Test
+    void streetQuery_nullName_throwsNpe() {
+        assertThrows(NullPointerException.class, () -> new ParsedQuery.StreetQuery(null));
+    }
+
+    @Test
+    void streetQuery_blankName_throwsIae() {
+        assertThrows(IllegalArgumentException.class, () -> new ParsedQuery.StreetQuery("  "));
+    }
+
+    // ==================== IntersectionQuery ====================
+
+    @Test
+    void intersectionQuery_validInput_createsInstance() {
+        var query = new ParsedQuery.IntersectionQuery("Mannerheimintie", "Aleksanterinkatu");
+        assertEquals("Mannerheimintie", query.roadA());
+        assertEquals("Aleksanterinkatu", query.roadB());
+    }
+
+    @Test
+    void intersectionQuery_nullRoadA_throwsNpe() {
+        assertThrows(NullPointerException.class, () -> new ParsedQuery.IntersectionQuery(null, "Aleksanterinkatu"));
+    }
+
+    @Test
+    void intersectionQuery_nullRoadB_throwsNpe() {
+        assertThrows(NullPointerException.class, () -> new ParsedQuery.IntersectionQuery("Mannerheimintie", null));
+    }
+
+    @Test
+    void intersectionQuery_blankRoadA_throwsIae() {
+        assertThrows(IllegalArgumentException.class, () -> new ParsedQuery.IntersectionQuery("  ", "Aleksanterinkatu"));
+    }
+
+    @Test
+    void intersectionQuery_blankRoadB_throwsIae() {
+        assertThrows(IllegalArgumentException.class, () -> new ParsedQuery.IntersectionQuery("Mannerheimintie", "  "));
+    }
+
+    // ==================== PlaceQuery ====================
+
+    @Test
+    void placeQuery_validInput_createsInstance() {
+        var query = new ParsedQuery.PlaceQuery("Helsinki");
+        assertEquals("Helsinki", query.name());
+    }
+
+    @Test
+    void placeQuery_nullName_throwsNpe() {
+        assertThrows(NullPointerException.class, () -> new ParsedQuery.PlaceQuery(null));
+    }
+
+    @Test
+    void placeQuery_blankName_throwsIae() {
+        assertThrows(IllegalArgumentException.class, () -> new ParsedQuery.PlaceQuery("  "));
+    }
+}

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/QueryParserTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/QueryParserTest.java
@@ -1,0 +1,138 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueryParserTest {
+
+    private final QueryParser parser = new QueryParser();
+
+    // ==================== Intersection detection ====================
+
+    @Test
+    void parse_intersectionWithSlash_returnsIntersectionQuery() {
+        var result = parser.parse("Mannerheimintie / Aleksanterinkatu");
+        assertInstanceOf(ParsedQuery.IntersectionQuery.class, result);
+        var iq = (ParsedQuery.IntersectionQuery) result;
+        assertEquals("Mannerheimintie", iq.roadA());
+        assertEquals("Aleksanterinkatu", iq.roadB());
+    }
+
+    @Test
+    void parse_intersectionWithAmpersand_returnsIntersectionQuery() {
+        var result = parser.parse("Mannerheimintie & Aleksanterinkatu");
+        assertInstanceOf(ParsedQuery.IntersectionQuery.class, result);
+    }
+
+    @Test
+    void parse_intersectionWithAnd_returnsIntersectionQuery() {
+        var result = parser.parse("Mannerheimintie and Aleksanterinkatu");
+        assertInstanceOf(ParsedQuery.IntersectionQuery.class, result);
+    }
+
+    @Test
+    void parse_intersectionWithJa_returnsIntersectionQuery() {
+        var result = parser.parse("Mannerheimintie ja Aleksanterinkatu");
+        assertInstanceOf(ParsedQuery.IntersectionQuery.class, result);
+    }
+
+    @Test
+    void parse_intersectionWithOch_returnsIntersectionQuery() {
+        var result = parser.parse("Mannerheimintie och Aleksanterinkatu");
+        assertInstanceOf(ParsedQuery.IntersectionQuery.class, result);
+    }
+
+    @Test
+    void parse_intersectionCaseInsensitiveSeparator_returnsIntersectionQuery() {
+        var result = parser.parse("Mannerheimintie JA Aleksanterinkatu");
+        assertInstanceOf(ParsedQuery.IntersectionQuery.class, result);
+    }
+
+    @Test
+    void parse_intersectionWithoutLetters_fallsThrough() {
+        // "123 / 456" — no letters on either side
+        var result = parser.parse("123 / 456");
+        // Should not be intersection since neither part contains letters
+        assertNotEquals(ParsedQuery.IntersectionQuery.class, result.getClass());
+    }
+
+    // ==================== Address detection ====================
+
+    @Test
+    void parse_addressWithNumber_returnsAddressQuery() {
+        var result = parser.parse("Mannerheimintie 5");
+        assertInstanceOf(ParsedQuery.AddressQuery.class, result);
+        var aq = (ParsedQuery.AddressQuery) result;
+        assertEquals("Mannerheimintie", aq.streetName());
+        assertEquals(5, aq.number());
+    }
+
+    @Test
+    void parse_addressWithLargeNumber_returnsAddressQuery() {
+        var result = parser.parse("Iso Roobertinkatu 123");
+        assertInstanceOf(ParsedQuery.AddressQuery.class, result);
+        var aq = (ParsedQuery.AddressQuery) result;
+        assertEquals("Iso Roobertinkatu", aq.streetName());
+        assertEquals(123, aq.number());
+    }
+
+    @Test
+    void parse_addressWithTrailingSpace_returnsAddressQuery() {
+        var result = parser.parse("Mannerheimintie 5 ");
+        assertInstanceOf(ParsedQuery.AddressQuery.class, result);
+    }
+
+    // ==================== Street detection ====================
+
+    @Test
+    void parse_multipleWordsWithoutNumber_returnsStreetQuery() {
+        var result = parser.parse("Iso Roobertinkatu");
+        assertInstanceOf(ParsedQuery.StreetQuery.class, result);
+        assertEquals("Iso Roobertinkatu", ((ParsedQuery.StreetQuery) result).name());
+    }
+
+    // ==================== Place detection ====================
+
+    @Test
+    void parse_singleWord_returnsPlaceQuery() {
+        var result = parser.parse("Helsinki");
+        assertInstanceOf(ParsedQuery.PlaceQuery.class, result);
+        assertEquals("Helsinki", ((ParsedQuery.PlaceQuery) result).name());
+    }
+
+    @Test
+    void parse_singleWordWithSurroundingSpaces_returnsPlaceQuery() {
+        var result = parser.parse("  Helsinki  ");
+        assertInstanceOf(ParsedQuery.PlaceQuery.class, result);
+        assertEquals("Helsinki", ((ParsedQuery.PlaceQuery) result).name());
+    }
+
+    // ==================== Error cases ====================
+
+    @Test
+    void parse_nullQuery_throwsNpe() {
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
+
+    @Test
+    void parse_blankQuery_throwsIae() {
+        assertThrows(IllegalArgumentException.class, () -> parser.parse("   "));
+    }
+
+    // ==================== Edge cases ====================
+
+    @Test
+    void parse_numberOnly_returnsPlaceQuery() {
+        // "123" has no whitespace, so it falls through to PlaceQuery
+        var result = parser.parse("123");
+        assertInstanceOf(ParsedQuery.PlaceQuery.class, result);
+    }
+
+    @Test
+    void parse_intersectionWithThreeParts_fallsThrough() {
+        // "A / B / C" splits into 3 parts, not 2
+        var result = parser.parse("Road A / Road B / Road C");
+        assertNotEquals(ParsedQuery.IntersectionQuery.class, result.getClass());
+    }
+}

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/ResultMergerTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/ResultMergerTest.java
@@ -1,0 +1,134 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.Coordinates;
+import net.pkhapps.idispatchx.common.domain.model.MultilingualName;
+import net.pkhapps.idispatchx.common.domain.model.Municipality;
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressResult;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressSource;
+import net.pkhapps.idispatchx.gis.server.api.geocode.IntersectionResult;
+import net.pkhapps.idispatchx.gis.server.api.geocode.PlaceResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResultMergerTest {
+
+    private final ResultMerger merger = new ResultMerger();
+
+    private static final Municipality MUNICIPALITY = Municipality.of(
+            MunicipalityCode.of("091"),
+            MultilingualName.ofFinnishFields("Helsinki", "Helsingfors", null, null, null));
+
+    private static final MultilingualName STREET_NAME =
+            MultilingualName.ofFinnishFields("Mannerheimintie", "Mannerheimvägen", null, null, null);
+
+    // ==================== Score sorting ====================
+
+    @Test
+    void merge_sortsResultsByScoreDescending() {
+        var low = scoredAddress("5", Coordinates.Epsg4326.of(60.17, 24.93), AddressSource.ADDRESS_POINT, 0.5);
+        var high = scoredAddress("7", Coordinates.Epsg4326.of(60.18, 24.94), AddressSource.ADDRESS_POINT, 0.9);
+        var mid = scoredAddress("9", Coordinates.Epsg4326.of(60.19, 24.95), AddressSource.ADDRESS_POINT, 0.7);
+
+        var results = merger.merge(List.of(low, high, mid), 10);
+
+        assertEquals(3, results.size());
+        assertEquals("7", ((AddressResult) results.get(0)).number());
+        assertEquals("9", ((AddressResult) results.get(1)).number());
+        assertEquals("5", ((AddressResult) results.get(2)).number());
+    }
+
+    // ==================== Limit ====================
+
+    @Test
+    void merge_limitsResultCount() {
+        var a = scoredAddress("1", Coordinates.Epsg4326.of(60.17, 24.93), AddressSource.ADDRESS_POINT, 0.9);
+        var b = scoredAddress("2", Coordinates.Epsg4326.of(60.18, 24.94), AddressSource.ADDRESS_POINT, 0.8);
+        var c = scoredAddress("3", Coordinates.Epsg4326.of(60.19, 24.95), AddressSource.ADDRESS_POINT, 0.7);
+
+        var results = merger.merge(List.of(a, b, c), 2);
+        assertEquals(2, results.size());
+    }
+
+    // ==================== ADDRESS_POINT > ROAD_SEGMENT ====================
+
+    @Test
+    void merge_addressPointPreferredOverRoadSegment_sameAddress() {
+        var addressPoint = scoredAddress("5", Coordinates.Epsg4326.of(60.17, 24.93), AddressSource.ADDRESS_POINT, 0.85);
+        var roadSegment = scoredAddress("5", Coordinates.Epsg4326.of(60.171, 24.931), AddressSource.ROAD_SEGMENT, 0.90);
+
+        // roadSegment has higher score but ADDRESS_POINT should win for same address
+        var results = merger.merge(List.of(roadSegment, addressPoint), 10);
+
+        assertEquals(1, results.size());
+        var addr = (AddressResult) results.getFirst();
+        assertEquals(AddressSource.ADDRESS_POINT, addr.source());
+    }
+
+    @Test
+    void merge_addressPointReplacesRoadSegment_whenAddressPointComesSecond() {
+        var roadSegment = scoredAddress("5", Coordinates.Epsg4326.of(60.171, 24.931), AddressSource.ROAD_SEGMENT, 0.95);
+        var addressPoint = scoredAddress("5", Coordinates.Epsg4326.of(60.17, 24.93), AddressSource.ADDRESS_POINT, 0.80);
+
+        var results = merger.merge(List.of(roadSegment, addressPoint), 10);
+
+        assertEquals(1, results.size());
+        var addr = (AddressResult) results.getFirst();
+        assertEquals(AddressSource.ADDRESS_POINT, addr.source());
+    }
+
+    // ==================== Proximity dedup ====================
+
+    @Test
+    void merge_proximityDedup_sameType() {
+        var a = scoredPlace("Senaatintori", Coordinates.Epsg4326.of(60.1699, 24.9527), 0.9);
+        var b = scoredPlace("Senatstorget", Coordinates.Epsg4326.of(60.16995, 24.95275), 0.85);
+
+        var results = merger.merge(List.of(a, b), 10);
+
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    void merge_noProximityDedup_differentTypes() {
+        var addr = scoredAddress("5", Coordinates.Epsg4326.of(60.17, 24.93), AddressSource.ADDRESS_POINT, 0.9);
+        var place = scoredPlace("Senaatintori", Coordinates.Epsg4326.of(60.17, 24.93), 0.85);
+
+        var results = merger.merge(List.of(addr, place), 10);
+
+        assertEquals(2, results.size());
+    }
+
+    @Test
+    void merge_noProximityDedup_farApart() {
+        var a = scoredPlace("Helsinki", Coordinates.Epsg4326.of(60.17, 24.93), 0.9);
+        var b = scoredPlace("Espoo", Coordinates.Epsg4326.of(60.20, 24.65), 0.85);
+
+        var results = merger.merge(List.of(a, b), 10);
+
+        assertEquals(2, results.size());
+    }
+
+    // ==================== Empty input ====================
+
+    @Test
+    void merge_emptyInput_returnsEmptyList() {
+        var results = merger.merge(List.of(), 10);
+        assertTrue(results.isEmpty());
+    }
+
+    // ==================== helpers ====================
+
+    private ScoredResult scoredAddress(String number, Coordinates.Epsg4326 coords, AddressSource source, double score) {
+        return new ScoredResult(new AddressResult(STREET_NAME, number, MUNICIPALITY, coords, source), score);
+    }
+
+    private ScoredResult scoredPlace(String nameFi, Coordinates.Epsg4326 coords, double score) {
+        return new ScoredResult(new PlaceResult(
+                MultilingualName.ofFinnishFields(nameFi, null, null, null, null),
+                48111, MUNICIPALITY, coords), score);
+    }
+}

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/RoadSegmentSearcherTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/geocode/RoadSegmentSearcherTest.java
@@ -1,0 +1,77 @@
+package net.pkhapps.idispatchx.gis.server.service.geocode;
+
+import net.pkhapps.idispatchx.common.domain.model.Coordinates;
+import net.pkhapps.idispatchx.common.domain.model.MultilingualName;
+import net.pkhapps.idispatchx.common.domain.model.Municipality;
+import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressResult;
+import net.pkhapps.idispatchx.gis.server.api.geocode.AddressSource;
+import net.pkhapps.idispatchx.gis.server.repository.InterpolatedAddressResult;
+import net.pkhapps.idispatchx.gis.server.repository.RoadSegmentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RoadSegmentSearcherTest {
+
+    @Mock
+    private RoadSegmentRepository repository;
+
+    private static final MunicipalityCode MUNI_CODE = MunicipalityCode.of("091");
+    private static final Municipality MUNICIPALITY = Municipality.of(
+            MUNI_CODE, MultilingualName.ofFinnishFields("Helsinki", "Helsingfors", null, null, null));
+    private static final Coordinates.Epsg4326 COORDS = Coordinates.Epsg4326.of(60.1699, 24.9384);
+
+    @Test
+    void searchAddress_found_returnsSingleResult() {
+        var searcher = new RoadSegmentSearcher(repository);
+        var interpolated = new InterpolatedAddressResult(
+                MultilingualName.ofFinnishFields("Mannerheimintie", "Mannerheimvägen", null, null, null),
+                "5", MUNICIPALITY, COORDS);
+
+        when(repository.interpolateAddress("Mannerheimintie", 5, null))
+                .thenReturn(Optional.of(interpolated));
+
+        var results = searcher.searchAddress("Mannerheimintie", 5, null);
+
+        assertEquals(1, results.size());
+        var scored = results.getFirst();
+        assertEquals(0.9, scored.score());
+        assertInstanceOf(AddressResult.class, scored.result());
+
+        var addr = (AddressResult) scored.result();
+        assertEquals("5", addr.number());
+        assertEquals(AddressSource.ROAD_SEGMENT, addr.source());
+    }
+
+    @Test
+    void searchAddress_notFound_returnsEmptyList() {
+        var searcher = new RoadSegmentSearcher(repository);
+        when(repository.interpolateAddress("NoSuchRoad", 1, null))
+                .thenReturn(Optional.empty());
+
+        var results = searcher.searchAddress("NoSuchRoad", 1, null);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void searchAddress_nullMunicipality_returnsEmptyList() {
+        var searcher = new RoadSegmentSearcher(repository);
+        var interpolated = new InterpolatedAddressResult(
+                MultilingualName.ofFinnishFields("Mannerheimintie", null, null, null, null),
+                "5", null, COORDS);
+
+        when(repository.interpolateAddress("Mannerheimintie", 5, null))
+                .thenReturn(Optional.of(interpolated));
+
+        var results = searcher.searchAddress("Mannerheimintie", 5, null);
+        assertTrue(results.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary

- Implement geocoding REST endpoint `GET /api/v1/geocode/search` with query parsing, parallel multi-source searching via virtual threads, result merging with deduplication, and Javalin controller wiring
- Add `QueryParser` that classifies search strings into address, street, intersection, or place query types
- Add 4 searcher classes (`AddressPointSearcher`, `RoadSegmentSearcher`, `NamedPlaceSearcher`, `IntersectionSearcher`) wrapping existing Phase 3 repositories
- Add `ResultMerger` for deduplication by address identity and coordinate proximity, with ADDRESS_POINT preferred over ROAD_SEGMENT
- Add `GeocodeService` orchestrator using `Executors.newVirtualThreadPerTaskExecutor()` for parallel search dispatch
- Wire geocoding into `GisServer.java` with JWT + role auth filters on `/api/v1/geocode/*`

## Test plan

- [x] 380 tests pass (including all existing Phase 0-4 tests, no regressions)
- [x] New tests cover: ParsedQuery validation (16 tests), QueryParser pattern detection (17 tests), all 4 searchers with mock repositories, ResultMerger dedup logic, GeocodeController validation/503 handling
- [ ] Manual integration test with running PostgreSQL + PostGIS database

🤖 Generated with [Claude Code](https://claude.com/claude-code)