### PR TITLE
GIS Server Phase 6: Health & Error Handling

### DIFF
--- a/Implementation/pom.xml
+++ b/Implementation/pom.xml
@@ -61,6 +61,11 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
 
             <!-- JWT -->
             <dependency>

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/GisServer.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/GisServer.java
@@ -9,7 +9,9 @@ import net.pkhapps.idispatchx.common.auth.LogoutTokenValidator;
 import net.pkhapps.idispatchx.common.auth.Role;
 import net.pkhapps.idispatchx.common.auth.SessionStore;
 import net.pkhapps.idispatchx.common.auth.TokenValidator;
+import net.pkhapps.idispatchx.gis.server.api.error.GlobalExceptionHandler;
 import net.pkhapps.idispatchx.gis.server.api.geocode.GeocodeController;
+import net.pkhapps.idispatchx.gis.server.api.health.HealthController;
 import net.pkhapps.idispatchx.gis.server.api.wmts.CapabilitiesGenerator;
 import net.pkhapps.idispatchx.gis.server.api.wmts.WmtsController;
 import net.pkhapps.idispatchx.gis.server.auth.BackChannelLogoutHandler;
@@ -111,7 +113,12 @@ public final class GisServer implements AutoCloseable {
                 new NamedPlaceSearcher(namedPlaceRepo),
                 new IntersectionSearcher(roadSegmentRepo));
 
+        // Register global exception handler
+        GlobalExceptionHandler.register(javalin);
+
         // Register routes
+        new HealthController(dataSourceProvider.getDataSource(), config.tileDirectory(), layers)
+                .registerRoutes(javalin);
         new WmtsController(tileService, capGen).registerRoutes(javalin, jwtAuth, roleAuth);
         new GeocodeController(geocodeService).registerRoutes(javalin, jwtAuth, roleAuth);
         javalin.post("/api/v1/auth/logout", logoutHandler);

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/error/GisErrorCode.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/error/GisErrorCode.java
@@ -1,0 +1,35 @@
+package net.pkhapps.idispatchx.gis.server.api.error;
+
+/**
+ * Error codes specific to the GIS Server.
+ * <p>
+ * These codes are used in {@link net.pkhapps.idispatchx.common.api.ErrorResponse}
+ * to identify GIS-specific error conditions. Common error codes are defined in
+ * {@link net.pkhapps.idispatchx.common.api.CommonErrorCode}.
+ */
+public final class GisErrorCode {
+
+    private GisErrorCode() {
+        // Utility class
+    }
+
+    /**
+     * Search query validation failed (too short, too long, etc.).
+     */
+    public static final String INVALID_QUERY = "INVALID_QUERY";
+
+    /**
+     * Request parameter validation failed (invalid limit, municipality code, etc.).
+     */
+    public static final String INVALID_PARAMETER = "INVALID_PARAMETER";
+
+    /**
+     * Tile coordinates are outside the valid range for the requested zoom level.
+     */
+    public static final String INVALID_TILE_COORDINATES = "INVALID_TILE_COORDINATES";
+
+    /**
+     * The requested tile layer does not exist.
+     */
+    public static final String LAYER_NOT_FOUND = "LAYER_NOT_FOUND";
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/error/GlobalExceptionHandler.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/error/GlobalExceptionHandler.java
@@ -1,0 +1,109 @@
+package net.pkhapps.idispatchx.gis.server.api.error;
+
+import io.javalin.Javalin;
+import io.javalin.http.BadRequestResponse;
+import io.javalin.http.Context;
+import io.javalin.http.ForbiddenResponse;
+import io.javalin.http.HttpResponseException;
+import io.javalin.http.NotFoundResponse;
+import io.javalin.http.UnauthorizedResponse;
+import net.pkhapps.idispatchx.common.api.CommonErrorCode;
+import net.pkhapps.idispatchx.common.api.ErrorResponse;
+import net.pkhapps.idispatchx.common.api.ValidationException;
+import net.pkhapps.idispatchx.gis.server.service.geocode.DatabaseUnavailableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Centralized exception handler for all GIS Server API endpoints.
+ * <p>
+ * Converts exceptions to standardized {@link ErrorResponse} JSON responses.
+ * All error responses follow the format defined in the technical design.
+ * <p>
+ * Exception to status code mapping:
+ * <ul>
+ *   <li>{@link ValidationException} → 400 Bad Request</li>
+ *   <li>{@link BadRequestResponse} → 400 Bad Request</li>
+ *   <li>{@link UnauthorizedResponse} → 401 Unauthorized</li>
+ *   <li>{@link ForbiddenResponse} → 403 Forbidden</li>
+ *   <li>{@link NotFoundResponse} → 404 Not Found</li>
+ *   <li>{@link DatabaseUnavailableException} → 503 Service Unavailable</li>
+ *   <li>{@link Exception} (catch-all) → 500 Internal Server Error</li>
+ * </ul>
+ */
+public final class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    private GlobalExceptionHandler() {
+        // Utility class
+    }
+
+    /**
+     * Registers all exception handlers on the given Javalin instance.
+     *
+     * @param app the Javalin application
+     */
+    public static void register(Javalin app) {
+        app.exception(ValidationException.class, GlobalExceptionHandler::handleValidationException);
+        app.exception(BadRequestResponse.class, GlobalExceptionHandler::handleBadRequest);
+        app.exception(UnauthorizedResponse.class, GlobalExceptionHandler::handleUnauthorized);
+        app.exception(ForbiddenResponse.class, GlobalExceptionHandler::handleForbidden);
+        app.exception(NotFoundResponse.class, GlobalExceptionHandler::handleNotFound);
+        app.exception(DatabaseUnavailableException.class, GlobalExceptionHandler::handleDatabaseUnavailable);
+        app.exception(HttpResponseException.class, GlobalExceptionHandler::handleHttpResponseException);
+        app.exception(Exception.class, GlobalExceptionHandler::handleUnexpected);
+    }
+
+    private static void handleValidationException(ValidationException e, Context ctx) {
+        log.debug("Validation error on {}: {} - {}", ctx.path(), e.getErrorCode(), e.getMessage());
+        ctx.status(400);
+        if (e.getDetails() != null) {
+            ctx.json(ErrorResponse.of(e.getErrorCode(), e.getMessage(), e.getDetails(), ctx.path()));
+        } else {
+            ctx.json(ErrorResponse.of(e.getErrorCode(), e.getMessage(), ctx.path()));
+        }
+    }
+
+    private static void handleBadRequest(BadRequestResponse e, Context ctx) {
+        log.debug("Bad request on {}: {}", ctx.path(), e.getMessage());
+        ctx.status(400);
+        ctx.json(ErrorResponse.of(GisErrorCode.INVALID_PARAMETER, e.getMessage(), ctx.path()));
+    }
+
+    private static void handleUnauthorized(UnauthorizedResponse e, Context ctx) {
+        log.debug("Unauthorized request on {}: {}", ctx.path(), e.getMessage());
+        ctx.status(401);
+        ctx.json(ErrorResponse.of(CommonErrorCode.UNAUTHORIZED, e.getMessage(), ctx.path()));
+    }
+
+    private static void handleForbidden(ForbiddenResponse e, Context ctx) {
+        log.debug("Forbidden request on {}: {}", ctx.path(), e.getMessage());
+        ctx.status(403);
+        ctx.json(ErrorResponse.of(CommonErrorCode.FORBIDDEN, e.getMessage(), ctx.path()));
+    }
+
+    private static void handleNotFound(NotFoundResponse e, Context ctx) {
+        log.debug("Not found on {}: {}", ctx.path(), e.getMessage());
+        ctx.status(404);
+        ctx.json(ErrorResponse.of(GisErrorCode.LAYER_NOT_FOUND, e.getMessage(), ctx.path()));
+    }
+
+    private static void handleDatabaseUnavailable(DatabaseUnavailableException e, Context ctx) {
+        log.warn("Database unavailable on {}: {}", ctx.path(), e.getMessage());
+        ctx.status(503);
+        ctx.json(ErrorResponse.of(CommonErrorCode.DATABASE_ERROR, "Database service unavailable", ctx.path()));
+    }
+
+    private static void handleHttpResponseException(HttpResponseException e, Context ctx) {
+        log.debug("HTTP error {} on {}: {}", e.getStatus(), ctx.path(), e.getMessage());
+        ctx.status(e.getStatus());
+        ctx.json(ErrorResponse.of(CommonErrorCode.INTERNAL_ERROR, e.getMessage(), ctx.path()));
+    }
+
+    private static void handleUnexpected(Exception e, Context ctx) {
+        log.error("Unexpected error on {}: {}", ctx.path(), e.getMessage(), e);
+        ctx.status(500);
+        ctx.json(ErrorResponse.of(CommonErrorCode.INTERNAL_ERROR, "An unexpected error occurred", ctx.path()));
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/error/package-info.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/error/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Error handling infrastructure for the GIS Server API, including
+ * GIS-specific error codes and the global exception handler.
+ */
+@NullMarked
+package net.pkhapps.idispatchx.gis.server.api.error;
+
+import org.jspecify.annotations.NullMarked;

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/geocode/GeocodeController.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/geocode/GeocodeController.java
@@ -1,9 +1,10 @@
 package net.pkhapps.idispatchx.gis.server.api.geocode;
 
 import io.javalin.Javalin;
-import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
+import net.pkhapps.idispatchx.common.api.ValidationException;
+import net.pkhapps.idispatchx.gis.server.api.error.GisErrorCode;
 import net.pkhapps.idispatchx.gis.server.service.geocode.DatabaseUnavailableException;
 import net.pkhapps.idispatchx.gis.server.service.geocode.GeocodeService;
 
@@ -50,11 +51,26 @@ public final class GeocodeController {
         var limitStr = ctx.queryParam("limit");
         var municipality = ctx.queryParam("municipality");
 
+        // Validate the query parameter first so it produces INVALID_QUERY (not INVALID_PARAMETER)
+        if (q == null || q.isBlank()) {
+            throw new ValidationException(GisErrorCode.INVALID_QUERY, "query is required");
+        }
+        var trimmedQuery = q.trim();
+        if (trimmedQuery.length() < SearchRequest.MIN_QUERY_LENGTH) {
+            throw new ValidationException(GisErrorCode.INVALID_QUERY,
+                    "query must be at least " + SearchRequest.MIN_QUERY_LENGTH + " characters");
+        }
+        if (trimmedQuery.length() > SearchRequest.MAX_QUERY_LENGTH) {
+            throw new ValidationException(GisErrorCode.INVALID_QUERY,
+                    "query must not exceed " + SearchRequest.MAX_QUERY_LENGTH + " characters");
+        }
+
+        // Remaining validation (limit, municipality) produces INVALID_PARAMETER
         SearchRequest request;
         try {
             request = SearchRequest.of(q, limitStr, municipality);
-        } catch (IllegalArgumentException | NullPointerException e) {
-            throw new BadRequestResponse(e.getMessage());
+        } catch (IllegalArgumentException e) {
+            throw new ValidationException(GisErrorCode.INVALID_PARAMETER, e.getMessage());
         }
 
         try {

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/health/HealthController.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/health/HealthController.java
@@ -1,0 +1,132 @@
+package net.pkhapps.idispatchx.gis.server.api.health;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.javalin.Javalin;
+import io.javalin.http.Context;
+import io.javalin.http.HttpStatus;
+import net.pkhapps.idispatchx.gis.server.model.TileLayer;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Health check endpoint for infrastructure monitoring.
+ * <p>
+ * This is an internal endpoint not exposed through the public reverse proxy
+ * (per Security NFR). It does not require authentication.
+ * <p>
+ * Checks:
+ * <ul>
+ *   <li>Database connectivity (execute simple query)</li>
+ *   <li>Tile directory accessibility (check exists and readable)</li>
+ *   <li>Discovered layers list</li>
+ * </ul>
+ * <p>
+ * Endpoint: {@code GET /health}
+ */
+public final class HealthController {
+
+    private static final Logger log = LoggerFactory.getLogger(HealthController.class);
+
+    private static final String STATUS_UP = "UP";
+    private static final String STATUS_DOWN = "DOWN";
+
+    private final DataSource dataSource;
+    private final Path tileDirectory;
+    private final Map<String, TileLayer> layers;
+
+    /**
+     * Creates a new health controller.
+     *
+     * @param dataSource    the data source for checking database connectivity
+     * @param tileDirectory the base path for tile storage
+     * @param layers        the discovered tile layers
+     */
+    public HealthController(DataSource dataSource, Path tileDirectory, Map<String, TileLayer> layers) {
+        this.dataSource = Objects.requireNonNull(dataSource, "dataSource must not be null");
+        this.tileDirectory = Objects.requireNonNull(tileDirectory, "tileDirectory must not be null");
+        this.layers = Map.copyOf(Objects.requireNonNull(layers, "layers must not be null"));
+    }
+
+    /**
+     * Registers the health check route on the given Javalin instance.
+     * No authentication filters are applied.
+     *
+     * @param app the Javalin application
+     */
+    public void registerRoutes(Javalin app) {
+        app.get("/health", this::handleHealthCheck);
+    }
+
+    private void handleHealthCheck(Context ctx) {
+        var components = new LinkedHashMap<String, Object>();
+        boolean allHealthy = true;
+
+        // Check database
+        var dbStatus = checkDatabase();
+        components.put("database", dbStatus);
+        if (!STATUS_UP.equals(dbStatus.get("status"))) {
+            allHealthy = false;
+        }
+
+        // Check tile directory
+        var tileStatus = checkTileDirectory();
+        components.put("tileDirectory", tileStatus);
+        if (!STATUS_UP.equals(tileStatus.get("status"))) {
+            allHealthy = false;
+        }
+
+        var response = new LinkedHashMap<String, Object>();
+        response.put("status", allHealthy ? STATUS_UP : STATUS_DOWN);
+        response.put("components", components);
+
+        ctx.status(allHealthy ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE);
+        ctx.json(response);
+    }
+
+    Map<String, Object> checkDatabase() {
+        var result = new LinkedHashMap<String, Object>();
+        try (var connection = dataSource.getConnection();
+             var statement = connection.createStatement();
+             var rs = statement.executeQuery("SELECT 1")) {
+            if (rs.next()) {
+                result.put("status", STATUS_UP);
+            } else {
+                result.put("status", STATUS_DOWN);
+                result.put("error", "Query returned no results");
+            }
+        } catch (SQLException e) {
+            log.warn("Database health check failed: {}", e.getMessage());
+            result.put("status", STATUS_DOWN);
+            result.put("error", e.getMessage());
+        }
+        return result;
+    }
+
+    Map<String, Object> checkTileDirectory() {
+        var result = new LinkedHashMap<String, Object>();
+        if (Files.isDirectory(tileDirectory) && Files.isReadable(tileDirectory)) {
+            result.put("status", STATUS_UP);
+            result.put("layers", List.copyOf(layers.keySet()));
+        } else {
+            result.put("status", STATUS_DOWN);
+            if (!Files.exists(tileDirectory)) {
+                result.put("error", "Tile directory does not exist");
+            } else if (!Files.isDirectory(tileDirectory)) {
+                result.put("error", "Tile path is not a directory");
+            } else {
+                result.put("error", "Tile directory is not readable");
+            }
+        }
+        return result;
+    }
+}

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/health/package-info.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/health/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Health check endpoint for infrastructure monitoring.
+ */
+@NullMarked
+package net.pkhapps.idispatchx.gis.server.api.health;
+
+import org.jspecify.annotations.NullMarked;

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/error/GisErrorCodeTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/error/GisErrorCodeTest.java
@@ -1,0 +1,16 @@
+package net.pkhapps.idispatchx.gis.server.api.error;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GisErrorCodeTest {
+
+    @Test
+    void errorCodes_haveExpectedValues() {
+        assertEquals("INVALID_QUERY", GisErrorCode.INVALID_QUERY);
+        assertEquals("INVALID_PARAMETER", GisErrorCode.INVALID_PARAMETER);
+        assertEquals("INVALID_TILE_COORDINATES", GisErrorCode.INVALID_TILE_COORDINATES);
+        assertEquals("LAYER_NOT_FOUND", GisErrorCode.LAYER_NOT_FOUND);
+    }
+}

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/error/GlobalExceptionHandlerTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,173 @@
+package net.pkhapps.idispatchx.gis.server.api.error;
+
+import io.javalin.Javalin;
+import io.javalin.http.BadRequestResponse;
+import io.javalin.http.Context;
+import io.javalin.http.ForbiddenResponse;
+import io.javalin.http.NotFoundResponse;
+import io.javalin.http.UnauthorizedResponse;
+import net.pkhapps.idispatchx.common.api.CommonErrorCode;
+import net.pkhapps.idispatchx.common.api.ErrorResponse;
+import net.pkhapps.idispatchx.common.api.ValidationException;
+import net.pkhapps.idispatchx.gis.server.service.geocode.DatabaseUnavailableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+    @Mock
+    private Context ctx;
+
+    @BeforeEach
+    void setUp() {
+        when(ctx.path()).thenReturn("/test");
+    }
+
+    // ==================== ValidationException ====================
+
+    @Test
+    void handleValidationException_returns400WithErrorCode() throws Exception {
+        var exception = new ValidationException("INVALID_QUERY", "Query too short");
+        invokeHandler(ValidationException.class, exception);
+
+        verify(ctx).status(400);
+        var response = captureJsonResponse();
+        assertEquals("INVALID_QUERY", response.error().code());
+        assertEquals("Query too short", response.error().message());
+        assertNull(response.error().details());
+    }
+
+    @Test
+    void handleValidationException_withDetails_includesDetails() throws Exception {
+        var details = Map.<String, Object>of("minLength", 3);
+        var exception = new ValidationException("INVALID_QUERY", "Query too short", details);
+        invokeHandler(ValidationException.class, exception);
+
+        verify(ctx).status(400);
+        var response = captureJsonResponse();
+        assertEquals("INVALID_QUERY", response.error().code());
+        assertNotNull(response.error().details());
+        assertEquals(3, response.error().details().get("minLength"));
+    }
+
+    // ==================== BadRequestResponse ====================
+
+    @Test
+    void handleBadRequest_returns400() throws Exception {
+        invokeHandler(BadRequestResponse.class, new BadRequestResponse("Invalid input"));
+
+        verify(ctx).status(400);
+        var response = captureJsonResponse();
+        assertEquals(GisErrorCode.INVALID_PARAMETER, response.error().code());
+        assertEquals("Invalid input", response.error().message());
+    }
+
+    // ==================== UnauthorizedResponse ====================
+
+    @Test
+    void handleUnauthorized_returns401() throws Exception {
+        invokeHandler(UnauthorizedResponse.class, new UnauthorizedResponse("Missing token"));
+
+        verify(ctx).status(401);
+        var response = captureJsonResponse();
+        assertEquals(CommonErrorCode.UNAUTHORIZED, response.error().code());
+        assertEquals("Missing token", response.error().message());
+    }
+
+    // ==================== ForbiddenResponse ====================
+
+    @Test
+    void handleForbidden_returns403() throws Exception {
+        invokeHandler(ForbiddenResponse.class, new ForbiddenResponse("Insufficient permissions"));
+
+        verify(ctx).status(403);
+        var response = captureJsonResponse();
+        assertEquals(CommonErrorCode.FORBIDDEN, response.error().code());
+        assertEquals("Insufficient permissions", response.error().message());
+    }
+
+    // ==================== NotFoundResponse ====================
+
+    @Test
+    void handleNotFound_returns404() throws Exception {
+        invokeHandler(NotFoundResponse.class, new NotFoundResponse("Unknown layer: foo"));
+
+        verify(ctx).status(404);
+        var response = captureJsonResponse();
+        assertEquals(GisErrorCode.LAYER_NOT_FOUND, response.error().code());
+        assertEquals("Unknown layer: foo", response.error().message());
+    }
+
+    // ==================== DatabaseUnavailableException ====================
+
+    @Test
+    void handleDatabaseUnavailable_returns503() throws Exception {
+        invokeHandler(DatabaseUnavailableException.class,
+                new DatabaseUnavailableException("Connection refused", new RuntimeException()));
+
+        verify(ctx).status(503);
+        var response = captureJsonResponse();
+        assertEquals(CommonErrorCode.DATABASE_ERROR, response.error().code());
+        assertEquals("Database service unavailable", response.error().message());
+    }
+
+    // ==================== Unexpected exceptions ====================
+
+    @Test
+    void handleUnexpected_returns500() throws Exception {
+        invokeHandler(Exception.class, new RuntimeException("Something went wrong"));
+
+        verify(ctx).status(500);
+        var response = captureJsonResponse();
+        assertEquals(CommonErrorCode.INTERNAL_ERROR, response.error().code());
+        assertEquals("An unexpected error occurred", response.error().message());
+    }
+
+    // ==================== Response includes path ====================
+
+    @Test
+    void allResponses_includeRequestPath() throws Exception {
+        when(ctx.path()).thenReturn("/api/v1/geocode/search");
+
+        invokeHandler(BadRequestResponse.class, new BadRequestResponse("test"));
+
+        var response = captureJsonResponse();
+        assertEquals("/api/v1/geocode/search", response.path());
+    }
+
+    // ==================== helpers ====================
+
+    @SuppressWarnings("unchecked")
+    private <T extends Exception> void invokeHandler(Class<T> exceptionType, T exception) throws Exception {
+        // Use reflection to invoke the private handler methods
+        var methodName = switch (exceptionType.getSimpleName()) {
+            case "ValidationException" -> "handleValidationException";
+            case "BadRequestResponse" -> "handleBadRequest";
+            case "UnauthorizedResponse" -> "handleUnauthorized";
+            case "ForbiddenResponse" -> "handleForbidden";
+            case "NotFoundResponse" -> "handleNotFound";
+            case "DatabaseUnavailableException" -> "handleDatabaseUnavailable";
+            default -> "handleUnexpected";
+        };
+
+        var method = GlobalExceptionHandler.class.getDeclaredMethod(methodName, exceptionType, Context.class);
+        method.setAccessible(true);
+        method.invoke(null, exception, ctx);
+    }
+
+    private ErrorResponse captureJsonResponse() {
+        var captor = ArgumentCaptor.forClass(ErrorResponse.class);
+        verify(ctx).json(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/geocode/GeocodeControllerTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/geocode/GeocodeControllerTest.java
@@ -1,11 +1,12 @@
 package net.pkhapps.idispatchx.gis.server.api.geocode;
 
-import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
+import net.pkhapps.idispatchx.common.api.ValidationException;
 import net.pkhapps.idispatchx.common.domain.model.Coordinates;
 import net.pkhapps.idispatchx.common.domain.model.MultilingualName;
 import net.pkhapps.idispatchx.common.domain.model.Municipality;
 import net.pkhapps.idispatchx.common.domain.model.MunicipalityCode;
+import net.pkhapps.idispatchx.gis.server.api.error.GisErrorCode;
 import net.pkhapps.idispatchx.gis.server.service.geocode.DatabaseUnavailableException;
 import net.pkhapps.idispatchx.gis.server.service.geocode.GeocodeService;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,33 +62,48 @@ class GeocodeControllerTest {
         verify(ctx).json(response);
     }
 
-    // ==================== Validation errors ====================
+    // ==================== Query validation errors → INVALID_QUERY ====================
 
     @Test
-    void handleSearch_nullQuery_throws400() {
+    void handleSearch_nullQuery_throwsValidationExceptionWithInvalidQueryCode() {
         when(ctx.queryParam("q")).thenReturn(null);
         when(ctx.queryParam("limit")).thenReturn(null);
         when(ctx.queryParam("municipality")).thenReturn(null);
 
-        assertThrows(BadRequestResponse.class, this::invokeHandleSearch);
+        var ex = assertThrows(ValidationException.class, this::invokeHandleSearch);
+        assertEquals(GisErrorCode.INVALID_QUERY, ex.getErrorCode());
     }
 
     @Test
-    void handleSearch_queryTooShort_throws400() {
+    void handleSearch_blankQuery_throwsValidationExceptionWithInvalidQueryCode() {
+        when(ctx.queryParam("q")).thenReturn("  ");
+        when(ctx.queryParam("limit")).thenReturn(null);
+        when(ctx.queryParam("municipality")).thenReturn(null);
+
+        var ex = assertThrows(ValidationException.class, this::invokeHandleSearch);
+        assertEquals(GisErrorCode.INVALID_QUERY, ex.getErrorCode());
+    }
+
+    @Test
+    void handleSearch_queryTooShort_throwsValidationExceptionWithInvalidQueryCode() {
         when(ctx.queryParam("q")).thenReturn("ab");
         when(ctx.queryParam("limit")).thenReturn(null);
         when(ctx.queryParam("municipality")).thenReturn(null);
 
-        assertThrows(BadRequestResponse.class, this::invokeHandleSearch);
+        var ex = assertThrows(ValidationException.class, this::invokeHandleSearch);
+        assertEquals(GisErrorCode.INVALID_QUERY, ex.getErrorCode());
     }
 
+    // ==================== Parameter validation errors → INVALID_PARAMETER ====================
+
     @Test
-    void handleSearch_invalidLimit_throws400() {
+    void handleSearch_invalidLimit_throwsValidationExceptionWithInvalidParameterCode() {
         when(ctx.queryParam("q")).thenReturn("Helsinki");
         when(ctx.queryParam("limit")).thenReturn("abc");
         when(ctx.queryParam("municipality")).thenReturn(null);
 
-        assertThrows(BadRequestResponse.class, this::invokeHandleSearch);
+        var ex = assertThrows(ValidationException.class, this::invokeHandleSearch);
+        assertEquals(GisErrorCode.INVALID_PARAMETER, ex.getErrorCode());
     }
 
     // ==================== Database unavailable ====================

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/health/HealthControllerTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/health/HealthControllerTest.java
@@ -1,0 +1,228 @@
+package net.pkhapps.idispatchx.gis.server.api.health;
+
+import io.javalin.http.Context;
+import io.javalin.http.HttpStatus;
+import net.pkhapps.idispatchx.gis.server.model.TileLayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.sql.DataSource;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HealthControllerTest {
+
+    @Mock
+    private DataSource dataSource;
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private Statement statement;
+
+    @Mock
+    private ResultSet resultSet;
+
+    @Mock
+    private Context ctx;
+
+    @TempDir
+    private Path tempDir;
+
+    // ==================== checkDatabase ====================
+
+    @Test
+    void checkDatabase_connectionSucceeds_returnsUp() throws Exception {
+        setupDbSuccess();
+        var controller = createController(tempDir, Map.of());
+
+        var result = controller.checkDatabase();
+
+        assertEquals("UP", result.get("status"));
+        assertFalse(result.containsKey("error"));
+    }
+
+    @Test
+    void checkDatabase_connectionFails_returnsDown() throws Exception {
+        when(dataSource.getConnection()).thenThrow(new SQLException("Connection refused"));
+        var controller = createController(tempDir, Map.of());
+
+        var result = controller.checkDatabase();
+
+        assertEquals("DOWN", result.get("status"));
+        assertEquals("Connection refused", result.get("error"));
+    }
+
+    // ==================== checkTileDirectory ====================
+
+    @Test
+    void checkTileDirectory_directoryExistsAndReadable_returnsUpWithLayers() {
+        var layers = Map.of("terrain", new TileLayer("terrain", Set.of(10, 11, 12)));
+        var controller = createController(tempDir, layers);
+
+        var result = controller.checkTileDirectory();
+
+        assertEquals("UP", result.get("status"));
+        @SuppressWarnings("unchecked")
+        var layerList = (List<String>) result.get("layers");
+        assertTrue(layerList.contains("terrain"));
+    }
+
+    @Test
+    void checkTileDirectory_directoryDoesNotExist_returnsDown() {
+        var nonExistent = tempDir.resolve("does-not-exist");
+        var controller = createController(nonExistent, Map.of());
+
+        var result = controller.checkTileDirectory();
+
+        assertEquals("DOWN", result.get("status"));
+        assertEquals("Tile directory does not exist", result.get("error"));
+    }
+
+    @Test
+    void checkTileDirectory_pathIsFile_returnsDown() throws Exception {
+        var filePath = tempDir.resolve("not-a-dir.txt");
+        Files.writeString(filePath, "content");
+        var controller = createController(filePath, Map.of());
+
+        var result = controller.checkTileDirectory();
+
+        assertEquals("DOWN", result.get("status"));
+        assertEquals("Tile path is not a directory", result.get("error"));
+    }
+
+    // ==================== handleHealthCheck ====================
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handleHealthCheck_allHealthy_returns200WithStatusUp() throws Exception {
+        setupDbSuccess();
+        var layers = Map.of("terrain", new TileLayer("terrain", Set.of(10)));
+        var controller = createController(tempDir, layers);
+
+        invokeHandleHealthCheck(controller);
+
+        verify(ctx).status(HttpStatus.OK);
+        var response = captureJsonResponse();
+        assertEquals("UP", response.get("status"));
+
+        var components = (Map<String, Object>) response.get("components");
+        var dbComponent = (Map<String, Object>) components.get("database");
+        assertEquals("UP", dbComponent.get("status"));
+
+        var tileComponent = (Map<String, Object>) components.get("tileDirectory");
+        assertEquals("UP", tileComponent.get("status"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handleHealthCheck_databaseDown_returns503WithStatusDown() throws Exception {
+        when(dataSource.getConnection()).thenThrow(new SQLException("Connection refused"));
+        var controller = createController(tempDir, Map.of());
+
+        invokeHandleHealthCheck(controller);
+
+        verify(ctx).status(HttpStatus.SERVICE_UNAVAILABLE);
+        var response = captureJsonResponse();
+        assertEquals("DOWN", response.get("status"));
+
+        var components = (Map<String, Object>) response.get("components");
+        var dbComponent = (Map<String, Object>) components.get("database");
+        assertEquals("DOWN", dbComponent.get("status"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void handleHealthCheck_tileDirectoryMissing_returns503() throws Exception {
+        setupDbSuccess();
+        var controller = createController(tempDir.resolve("nonexistent"), Map.of());
+
+        invokeHandleHealthCheck(controller);
+
+        verify(ctx).status(HttpStatus.SERVICE_UNAVAILABLE);
+        var response = captureJsonResponse();
+        assertEquals("DOWN", response.get("status"));
+    }
+
+    @Test
+    void handleHealthCheck_noLayersDiscovered_returns200WhenDirectoryAccessible() throws Exception {
+        setupDbSuccess();
+        var controller = createController(tempDir, Map.of());
+
+        invokeHandleHealthCheck(controller);
+
+        verify(ctx).status(HttpStatus.OK);
+    }
+
+    // ==================== constructor validation ====================
+
+    @Test
+    void constructor_nullDataSource_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new HealthController(null, tempDir, Map.of()));
+    }
+
+    @Test
+    void constructor_nullTileDirectory_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new HealthController(dataSource, null, Map.of()));
+    }
+
+    @Test
+    void constructor_nullLayers_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new HealthController(dataSource, tempDir, null));
+    }
+
+    // ==================== helpers ====================
+
+    private void setupDbSuccess() throws Exception {
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        when(statement.executeQuery("SELECT 1")).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+    }
+
+    private HealthController createController(Path tileDir, Map<String, TileLayer> layers) {
+        return new HealthController(dataSource, tileDir, layers);
+    }
+
+    private void invokeHandleHealthCheck(HealthController controller) throws Exception {
+        var method = HealthController.class.getDeclaredMethod("handleHealthCheck", Context.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(controller, ctx);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            var cause = e.getCause();
+            if (cause instanceof RuntimeException re) {
+                throw re;
+            }
+            throw e;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> captureJsonResponse() {
+        var captor = ArgumentCaptor.forClass(LinkedHashMap.class);
+        verify(ctx).json(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/Implementation/shared/java-common/pom.xml
+++ b/Implementation/shared/java-common/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/api/CommonErrorCode.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/api/CommonErrorCode.java
@@ -1,0 +1,35 @@
+package net.pkhapps.idispatchx.common.api;
+
+/**
+ * Error codes shared across all server applications.
+ * <p>
+ * These codes are used in {@link ErrorResponse} to identify error categories
+ * that are common to all servers (authentication, authorization, database, etc.).
+ * Server-specific error codes should be defined in the respective server module.
+ */
+public final class CommonErrorCode {
+
+    private CommonErrorCode() {
+        // Utility class
+    }
+
+    /**
+     * Missing or invalid JWT token.
+     */
+    public static final String UNAUTHORIZED = "UNAUTHORIZED";
+
+    /**
+     * Valid JWT but insufficient role for the requested resource.
+     */
+    public static final String FORBIDDEN = "FORBIDDEN";
+
+    /**
+     * Database connection or query failure.
+     */
+    public static final String DATABASE_ERROR = "DATABASE_ERROR";
+
+    /**
+     * Unexpected server error.
+     */
+    public static final String INTERNAL_ERROR = "INTERNAL_ERROR";
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/api/ErrorResponse.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/api/ErrorResponse.java
@@ -1,0 +1,86 @@
+package net.pkhapps.idispatchx.common.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Standardized error response DTO used by all server API endpoints.
+ * <p>
+ * Produces JSON in the following format:
+ * <pre>
+ * {
+ *   "error": {
+ *     "code": "INVALID_QUERY",
+ *     "message": "Search query must be at least 3 characters",
+ *     "details": { "minLength": 3, "actualLength": 2 }
+ *   },
+ *   "timestamp": "2026-02-21T10:30:00Z",
+ *   "path": "/api/v1/geocode/search"
+ * }
+ * </pre>
+ *
+ * @param error     the error details
+ * @param timestamp the time the error occurred
+ * @param path      the request path that produced the error
+ */
+public record ErrorResponse(
+        ErrorBody error,
+        Instant timestamp,
+        String path
+) {
+
+    public ErrorResponse {
+        Objects.requireNonNull(error, "error must not be null");
+        Objects.requireNonNull(timestamp, "timestamp must not be null");
+        Objects.requireNonNull(path, "path must not be null");
+    }
+
+    /**
+     * The error detail body containing the error code, message, and optional details.
+     *
+     * @param code    the error code identifying the error type
+     * @param message a human-readable error message
+     * @param details optional additional details about the error (e.g., validation info)
+     */
+    public record ErrorBody(
+            String code,
+            String message,
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            @Nullable Map<String, Object> details
+    ) {
+
+        public ErrorBody {
+            Objects.requireNonNull(code, "code must not be null");
+            Objects.requireNonNull(message, "message must not be null");
+        }
+    }
+
+    /**
+     * Creates an error response without details.
+     *
+     * @param code    the error code
+     * @param message the error message
+     * @param path    the request path
+     * @return the error response
+     */
+    public static ErrorResponse of(String code, String message, String path) {
+        return new ErrorResponse(new ErrorBody(code, message, null), Instant.now(), path);
+    }
+
+    /**
+     * Creates an error response with details.
+     *
+     * @param code    the error code
+     * @param message the error message
+     * @param details additional details about the error
+     * @param path    the request path
+     * @return the error response
+     */
+    public static ErrorResponse of(String code, String message, Map<String, Object> details, String path) {
+        return new ErrorResponse(new ErrorBody(code, message, details), Instant.now(), path);
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/api/ValidationException.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/api/ValidationException.java
@@ -1,0 +1,60 @@
+package net.pkhapps.idispatchx.common.api;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Exception thrown when request validation fails.
+ * <p>
+ * This exception carries an error code and optional details map that are
+ * used by the global exception handler to produce a standardized
+ * {@link ErrorResponse} with HTTP 400 status.
+ */
+public class ValidationException extends RuntimeException {
+
+    private final String errorCode;
+    private final @Nullable Map<String, Object> details;
+
+    /**
+     * Creates a validation exception with an error code and message.
+     *
+     * @param errorCode the error code (e.g., "INVALID_QUERY")
+     * @param message   the human-readable error message
+     */
+    public ValidationException(String errorCode, String message) {
+        this(errorCode, message, null);
+    }
+
+    /**
+     * Creates a validation exception with an error code, message, and details.
+     *
+     * @param errorCode the error code (e.g., "INVALID_QUERY")
+     * @param message   the human-readable error message
+     * @param details   optional additional details about the validation failure
+     */
+    public ValidationException(String errorCode, String message, @Nullable Map<String, Object> details) {
+        super(message);
+        this.errorCode = Objects.requireNonNull(errorCode, "errorCode must not be null");
+        this.details = details;
+    }
+
+    /**
+     * Returns the error code for this validation failure.
+     *
+     * @return the error code
+     */
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    /**
+     * Returns the optional details map for this validation failure.
+     *
+     * @return the details map, or null if no details were provided
+     */
+    public @Nullable Map<String, Object> getDetails() {
+        return details;
+    }
+}

--- a/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/api/package-info.java
+++ b/Implementation/shared/java-common/src/main/java/net/pkhapps/idispatchx/common/api/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Shared API model classes for error responses and common error codes.
+ */
+@NullMarked
+package net.pkhapps.idispatchx.common.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/api/ErrorResponseTest.java
+++ b/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/api/ErrorResponseTest.java
@@ -1,0 +1,104 @@
+package net.pkhapps.idispatchx.common.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ErrorResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .findAndRegisterModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @Test
+    void of_withoutDetails_createsResponseWithNullDetails() {
+        var response = ErrorResponse.of("UNAUTHORIZED", "Missing token", "/api/v1/geocode/search");
+
+        assertEquals("UNAUTHORIZED", response.error().code());
+        assertEquals("Missing token", response.error().message());
+        assertNull(response.error().details());
+        assertEquals("/api/v1/geocode/search", response.path());
+        assertNotNull(response.timestamp());
+    }
+
+    @Test
+    void of_withDetails_createsResponseWithDetails() {
+        var details = Map.<String, Object>of("minLength", 3, "actualLength", 2);
+        var response = ErrorResponse.of("INVALID_QUERY", "Query too short", details, "/api/v1/geocode/search");
+
+        assertEquals("INVALID_QUERY", response.error().code());
+        assertEquals("Query too short", response.error().message());
+        assertEquals(details, response.error().details());
+        assertEquals("/api/v1/geocode/search", response.path());
+    }
+
+    @Test
+    void constructor_nullError_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new ErrorResponse(null, Instant.now(), "/test"));
+    }
+
+    @Test
+    void constructor_nullTimestamp_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new ErrorResponse(new ErrorResponse.ErrorBody("CODE", "msg", null), null, "/test"));
+    }
+
+    @Test
+    void constructor_nullPath_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new ErrorResponse(new ErrorResponse.ErrorBody("CODE", "msg", null), Instant.now(), null));
+    }
+
+    @Test
+    void errorBody_nullCode_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new ErrorResponse.ErrorBody(null, "msg", null));
+    }
+
+    @Test
+    void errorBody_nullMessage_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new ErrorResponse.ErrorBody("CODE", null, null));
+    }
+
+    @Test
+    void jsonSerialization_withoutDetails_excludesDetailsField() throws Exception {
+        var response = ErrorResponse.of("UNAUTHORIZED", "Missing token", "/test");
+        var json = objectMapper.writeValueAsString(response);
+        var tree = objectMapper.readTree(json);
+
+        assertEquals("UNAUTHORIZED", tree.get("error").get("code").asText());
+        assertEquals("Missing token", tree.get("error").get("message").asText());
+        assertFalse(tree.get("error").has("details"), "details should be excluded when null");
+        assertTrue(tree.has("timestamp"));
+        assertEquals("/test", tree.get("path").asText());
+    }
+
+    @Test
+    void jsonSerialization_withDetails_includesDetailsField() throws Exception {
+        var details = Map.<String, Object>of("minLength", 3);
+        var response = ErrorResponse.of("INVALID_QUERY", "Query too short", details, "/test");
+        var json = objectMapper.writeValueAsString(response);
+        var tree = objectMapper.readTree(json);
+
+        assertTrue(tree.get("error").has("details"));
+        assertEquals(3, tree.get("error").get("details").get("minLength").asInt());
+    }
+
+    @Test
+    void jsonSerialization_timestampIsIso8601() throws Exception {
+        var response = ErrorResponse.of("TEST", "test", "/test");
+        var json = objectMapper.writeValueAsString(response);
+        var tree = objectMapper.readTree(json);
+
+        var timestampStr = tree.get("timestamp").asText();
+        // Should parse as an ISO-8601 instant
+        assertDoesNotThrow(() -> Instant.parse(timestampStr));
+    }
+}

--- a/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/api/ValidationExceptionTest.java
+++ b/Implementation/shared/java-common/src/test/java/net/pkhapps/idispatchx/common/api/ValidationExceptionTest.java
@@ -1,0 +1,35 @@
+package net.pkhapps.idispatchx.common.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidationExceptionTest {
+
+    @Test
+    void constructor_withCodeAndMessage_setsFields() {
+        var exception = new ValidationException("INVALID_QUERY", "Query too short");
+
+        assertEquals("INVALID_QUERY", exception.getErrorCode());
+        assertEquals("Query too short", exception.getMessage());
+        assertNull(exception.getDetails());
+    }
+
+    @Test
+    void constructor_withDetails_setsAllFields() {
+        var details = Map.<String, Object>of("minLength", 3, "actualLength", 2);
+        var exception = new ValidationException("INVALID_QUERY", "Query too short", details);
+
+        assertEquals("INVALID_QUERY", exception.getErrorCode());
+        assertEquals("Query too short", exception.getMessage());
+        assertEquals(details, exception.getDetails());
+    }
+
+    @Test
+    void constructor_nullErrorCode_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new ValidationException(null, "message"));
+    }
+}

--- a/Spec/Plans/GIS-Server-Implementation-Plan.md
+++ b/Spec/Plans/GIS-Server-Implementation-Plan.md
@@ -23,8 +23,8 @@ This document contains the implementation plan for the GIS Server. It is organiz
 | 2 | Authentication & Security | 5 | Done |
 | 3 | Model & Repository Layer | 5 | Done |
 | 4 | WMTS Tile Service | 6 | Done |
-| 5 | Geocoding Service | 8 | Not Started |
-| 6 | Health & Error Handling | 3 | Not Started |
+| 5 | Geocoding Service | 8 | Done |
+| 6 | Health & Error Handling | 3 | Done |
 | 7 | Testing & Documentation | 4 | Not Started |
 | **Total** | | **38** | |
 
@@ -696,7 +696,7 @@ Geocoding REST endpoint for address, place, and intersection lookups.
 
 ### Task 5.1: Implement Query Parser
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Parse search queries to detect patterns (address with number, intersection, place name).
@@ -730,7 +730,7 @@ Parse search queries to detect patterns (address with number, intersection, plac
 
 ### Task 5.2: Implement Address Point Searcher
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Search address points for matching addresses.
@@ -754,7 +754,7 @@ Search address points for matching addresses.
 
 ### Task 5.3: Implement Road Segment Searcher
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Search road segments and interpolate addresses.
@@ -778,7 +778,7 @@ Search road segments and interpolate addresses.
 
 ### Task 5.4: Implement Named Place Searcher
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Search named places.
@@ -802,7 +802,7 @@ Search named places.
 
 ### Task 5.5: Implement Intersection Searcher
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Search for road intersections.
@@ -825,7 +825,7 @@ Search for road intersections.
 
 ### Task 5.6: Implement Result Merger
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Combine and rank results from multiple searchers.
@@ -854,7 +854,7 @@ Combine and rank results from multiple searchers.
 
 ### Task 5.7: Implement Geocode Service
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Orchestrate geocoding searches based on query type.
@@ -884,7 +884,7 @@ Orchestrate geocoding searches based on query type.
 
 ### Task 5.8: Implement Geocode Controller
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Javalin endpoint for geocoding.
@@ -917,14 +917,14 @@ Health check endpoint and centralized error handling.
 
 ### Task 6.1: Implement Health Controller
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Health check endpoint for infrastructure monitoring. This is an internal endpoint not exposed through the public reverse proxy (per Security NFR).
 
 **Package:** `net.pkhapps.idispatchx.gis.server.api.health`
 
-**Files to Create:**
+**Files Created:**
 - `HealthController.java`
 
 **Endpoint:**
@@ -936,11 +936,11 @@ Health check endpoint for infrastructure monitoring. This is an internal endpoin
 3. Discovered layers list
 
 **Acceptance Criteria:**
-- [ ] Returns 200 OK with status "UP" when all components healthy
-- [ ] Returns 503 Service Unavailable with status "DOWN" when any component unhealthy
-- [ ] Includes component-level status in response
-- [ ] Does not require authentication
-- [ ] Unit tests verify health check logic
+- [x] Returns 200 OK with status "UP" when all components healthy
+- [x] Returns 503 Service Unavailable with status "DOWN" when any component unhealthy
+- [x] Includes component-level status in response
+- [x] Does not require authentication
+- [x] Unit tests verify health check logic
 
 **Dependencies:** Task 1.2, Task 4.1
 
@@ -948,20 +948,20 @@ Health check endpoint for infrastructure monitoring. This is an internal endpoin
 
 ### Task 6.2: Implement Error Response Format
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Standardized error response DTOs. Common error codes are shared; server-specific codes remain in each server module.
 
 **Shared Module Package:** `net.pkhapps.idispatchx.common.api`
 
-**Shared Module Files to Create:**
+**Shared Module Files Created:**
 - `ErrorResponse.java` - Error response DTO (code, message, details, timestamp, path)
 - `CommonErrorCode.java` - Shared error codes (UNAUTHORIZED, FORBIDDEN, DATABASE_ERROR, INTERNAL_ERROR)
 
 **GIS Server Package:** `net.pkhapps.idispatchx.gis.server.api.error`
 
-**GIS Server Files to Create:**
+**GIS Server Files Created:**
 - `GisErrorCode.java` - GIS-specific error codes
 
 **GIS-Specific Error Codes:**
@@ -971,11 +971,11 @@ Standardized error response DTOs. Common error codes are shared; server-specific
 - LAYER_NOT_FOUND - Tile layer does not exist
 
 **Acceptance Criteria:**
-- [ ] All error codes from technical design are implemented
-- [ ] Error response includes timestamp and request path
-- [ ] Optional details field for validation errors
-- [ ] Jackson serialization produces expected format
-- [ ] Unit tests verify serialization
+- [x] All error codes from technical design are implemented
+- [x] Error response includes timestamp and request path
+- [x] Optional details field for validation errors
+- [x] Jackson serialization produces expected format
+- [x] Unit tests verify serialization
 
 **Dependencies:** None
 
@@ -983,30 +983,30 @@ Standardized error response DTOs. Common error codes are shared; server-specific
 
 ### Task 6.3: Implement Global Exception Handler
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Centralized exception handling for all endpoints. Uses shared ErrorResponse format.
 
 **Shared Module Package:** `net.pkhapps.idispatchx.common.api`
 
-**Shared Module Files to Create:**
+**Shared Module Files Created:**
 - `ValidationException.java` - Custom exception for validation errors
 
 **GIS Server Package:** `net.pkhapps.idispatchx.gis.server.api.error`
 
-**GIS Server Files to Create:**
+**GIS Server Files Created:**
 - `GlobalExceptionHandler.java` - Javalin exception handler
 
 **Acceptance Criteria:**
-- [ ] Catches ValidationException and returns 400
-- [ ] Catches authentication exceptions and returns 401
-- [ ] Catches authorization exceptions and returns 403
-- [ ] Catches database exceptions and returns 503
-- [ ] Catches unexpected exceptions and returns 500
-- [ ] Logs exceptions with appropriate levels (no PII)
-- [ ] All responses use ErrorResponse format
-- [ ] Unit tests verify exception mapping
+- [x] Catches ValidationException and returns 400
+- [x] Catches authentication exceptions and returns 401
+- [x] Catches authorization exceptions and returns 403
+- [x] Catches database exceptions and returns 503
+- [x] Catches unexpected exceptions and returns 500
+- [x] Logs exceptions with appropriate levels (no PII)
+- [x] All responses use ErrorResponse format
+- [x] Unit tests verify exception mapping
 
 **Dependencies:** Task 6.2
 


### PR DESCRIPTION
## Summary

- **Standardized error responses**: `ErrorResponse` DTO and error code constants (`CommonErrorCode` in shared module, `GisErrorCode` in GIS server) producing consistent JSON error format with code, message, optional details, timestamp, and request path
- **Health check endpoint**: `GET /health` (unauthenticated, internal-only per Security NFR) checking database connectivity, tile directory accessibility, and discovered layers — returns 200/UP or 503/DOWN with component-level status
- **Global exception handler**: Centralized Javalin exception handling converting `ValidationException` → 400, `UnauthorizedResponse` → 401, `ForbiddenResponse` → 403, `NotFoundResponse` → 404, `DatabaseUnavailableException` → 503, and unexpected exceptions → 500 — all using `ErrorResponse` format
- **Shared `ValidationException`**: Custom exception carrying error code and optional details map for structured validation error responses

## Files Changed

### Shared Module (`java-common`)
| File | Description |
|------|-------------|
| `common/api/package-info.java` | New `@NullMarked` package |
| `common/api/ErrorResponse.java` | Error response DTO with nested `ErrorBody` |
| `common/api/CommonErrorCode.java` | Shared error code constants |
| `common/api/ValidationException.java` | Validation failure exception |
| `pom.xml` | Added `jackson-datatype-jsr310` dependency |

### GIS Server
| File | Description |
|------|-------------|
| `api/error/package-info.java` | New `@NullMarked` package |
| `api/error/GisErrorCode.java` | GIS-specific error code constants |
| `api/error/GlobalExceptionHandler.java` | Centralized exception → ErrorResponse mapping |
| `api/health/package-info.java` | New `@NullMarked` package |
| `api/health/HealthController.java` | Health check endpoint |
| `GisServer.java` | Register exception handler and health controller |

### Plan
| File | Description |
|------|-------------|
| `GIS-Server-Implementation-Plan.md` | Phase 5 and 6 marked Done |

## Test plan
- [x] `ErrorResponseTest` — validation, serialization, null details exclusion, ISO-8601 timestamp
- [x] `ValidationExceptionTest` — constructor validation, field access
- [x] `GisErrorCodeTest` — error code values
- [x] `GlobalExceptionHandlerTest` — all exception types mapped to correct status/code
- [x] `HealthControllerTest` — DB up/down, tile directory exists/missing/file, all-healthy/partial-down
- [x] Full project `mvn clean package` passes (769 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)