### PR TITLE
GIS Server Phase 8: ADR-0007 tile coordinate domain primitive

### DIFF
--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/wmts/WmtsController.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/api/wmts/WmtsController.java
@@ -79,20 +79,14 @@ public final class WmtsController {
             throw new BadRequestResponse("Tile file must have .png extension");
         }
 
-        int zoom;
-        int row;
-        int col;
+        TileCoordinates coordinates;
         try {
-            zoom = Integer.parseInt(zoomStr);
-            row = Integer.parseInt(rowStr);
-            col = Integer.parseInt(colStr);
+            var zoom = Integer.parseInt(zoomStr);
+            var row = Integer.parseInt(rowStr);
+            var col = Integer.parseInt(colStr);
+            coordinates = TileCoordinates.of(zoom, row, col);
         } catch (NumberFormatException e) {
             throw new BadRequestResponse("Invalid tile coordinates: zoom, row, and col must be integers");
-        }
-
-        // Validate coordinates
-        try {
-            TileCoordinates.of(zoom, row, col);
         } catch (IllegalArgumentException e) {
             throw new BadRequestResponse("Invalid tile coordinates: " + e.getMessage());
         }
@@ -100,7 +94,7 @@ public final class WmtsController {
         // Retrieve tile
         TileService.TileResult result;
         try {
-            result = tileService.getTile(layerName, zoom, row, col);
+            result = tileService.getTile(layerName, coordinates);
         } catch (IllegalArgumentException e) {
             throw new NotFoundResponse("Unknown layer: " + layerName);
         } catch (TileService.TileNotFoundException e) {

--- a/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/tile/TileService.java
+++ b/Implementation/servers/gis-server/src/main/java/net/pkhapps/idispatchx/gis/server/service/tile/TileService.java
@@ -1,5 +1,6 @@
 package net.pkhapps.idispatchx.gis.server.service.tile;
 
+import net.pkhapps.idispatchx.gis.server.model.TileCoordinates;
 import net.pkhapps.idispatchx.gis.server.model.TileLayer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,19 +77,22 @@ public final class TileService {
      *   <li>Newly resampled tile (then cached)</li>
      * </ol>
      *
-     * @param layerName the name of the tile layer
-     * @param zoom      the zoom level
-     * @param row       the row index
-     * @param col       the column index
+     * @param layerName   the name of the tile layer
+     * @param coordinates the tile coordinates (zoom, row, col)
      * @return the tile result
      * @throws IllegalArgumentException if the layer is not known
      * @throws TileNotFoundException    if no tile can be produced for the given coordinates
      */
-    public TileResult getTile(String layerName, int zoom, int row, int col) {
+    public TileResult getTile(String layerName, TileCoordinates coordinates) {
+        Objects.requireNonNull(coordinates, "coordinates must not be null");
         var layer = layers.get(layerName);
         if (layer == null) {
             throw new IllegalArgumentException("Unknown layer: " + layerName);
         }
+
+        var zoom = coordinates.zoom();
+        var row = coordinates.row();
+        var col = coordinates.col();
 
         // Try pre-rendered tile first
         if (layer.hasZoomLevel(zoom)) {

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/wmts/WmtsControllerTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/api/wmts/WmtsControllerTest.java
@@ -4,6 +4,7 @@ import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.HttpStatus;
 import io.javalin.http.NotFoundResponse;
+import net.pkhapps.idispatchx.gis.server.model.TileCoordinates;
 import net.pkhapps.idispatchx.gis.server.service.tile.TileService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,7 @@ class WmtsControllerTest {
     @Test
     void getTile_unknownLayer_throws404() {
         setupTilePathParams("unknown", "10", "100", "200.png");
-        when(tileService.getTile("unknown", 10, 100, 200))
+        when(tileService.getTile("unknown", TileCoordinates.of(10, 100, 200)))
                 .thenThrow(new IllegalArgumentException("Unknown layer"));
 
         assertThrows(NotFoundResponse.class, this::invokeGetTile);
@@ -106,7 +107,7 @@ class WmtsControllerTest {
     @Test
     void getTile_tileNotFound_returns204() throws Exception {
         setupTilePathParams("terrain", "10", "100", "200.png");
-        when(tileService.getTile("terrain", 10, 100, 200))
+        when(tileService.getTile("terrain", TileCoordinates.of(10, 100, 200)))
                 .thenThrow(new TileService.TileNotFoundException("No tile"));
 
         invokeGetTile();
@@ -120,7 +121,7 @@ class WmtsControllerTest {
     void getTile_preRendered_returns200WithEtag() throws Exception {
         var data = new byte[]{1, 2, 3, 4};
         setupTilePathParams("terrain", "10", "100", "200.png");
-        when(tileService.getTile("terrain", 10, 100, 200))
+        when(tileService.getTile("terrain", TileCoordinates.of(10, 100, 200)))
                 .thenReturn(new TileService.TileResult.PreRendered(data));
         when(ctx.header("If-None-Match")).thenReturn(null);
 
@@ -137,7 +138,7 @@ class WmtsControllerTest {
     void getTile_preRendered_etagMatchReturns304() throws Exception {
         var data = new byte[]{1, 2, 3, 4};
         setupTilePathParams("terrain", "10", "100", "200.png");
-        when(tileService.getTile("terrain", 10, 100, 200))
+        when(tileService.getTile("terrain", TileCoordinates.of(10, 100, 200)))
                 .thenReturn(new TileService.TileResult.PreRendered(data));
 
         // Compute what the ETag will be
@@ -157,7 +158,7 @@ class WmtsControllerTest {
     void getTile_preRendered_differentEtagDoesNotReturn304() throws Exception {
         var data = new byte[]{1, 2, 3, 4};
         setupTilePathParams("terrain", "10", "100", "200.png");
-        when(tileService.getTile("terrain", 10, 100, 200))
+        when(tileService.getTile("terrain", TileCoordinates.of(10, 100, 200)))
                 .thenReturn(new TileService.TileResult.PreRendered(data));
         when(ctx.header("If-None-Match")).thenReturn("\"different-etag\"");
 
@@ -173,7 +174,7 @@ class WmtsControllerTest {
     void getTile_resampled_returns200WithShortCacheControl() throws Exception {
         var data = new byte[]{5, 6, 7, 8};
         setupTilePathParams("terrain", "11", "200", "400.png");
-        when(tileService.getTile("terrain", 11, 200, 400))
+        when(tileService.getTile("terrain", TileCoordinates.of(11, 200, 400)))
                 .thenReturn(new TileService.TileResult.Resampled(data));
 
         invokeGetTile();

--- a/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/tile/TileServiceTest.java
+++ b/Implementation/servers/gis-server/src/test/java/net/pkhapps/idispatchx/gis/server/service/tile/TileServiceTest.java
@@ -1,5 +1,6 @@
 package net.pkhapps.idispatchx.gis.server.service.tile;
 
+import net.pkhapps.idispatchx.gis.server.model.TileCoordinates;
 import net.pkhapps.idispatchx.gis.server.model.TileLayer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -26,7 +27,7 @@ class TileServiceTest {
         var service = new TileService(tileDir, layers, new TileResampler(tileDir), new TileCache());
 
         assertThrows(IllegalArgumentException.class,
-                () -> service.getTile("nonexistent", 10, 0, 0));
+                () -> service.getTile("nonexistent", TileCoordinates.of(10, 0, 0)));
     }
 
     @Test
@@ -36,7 +37,7 @@ class TileServiceTest {
         var layers = Map.of("terrain", new TileLayer("terrain", Set.of(10)));
         var service = new TileService(tileDir, layers, new TileResampler(tileDir), new TileCache());
 
-        var result = service.getTile("terrain", 10, 100, 200);
+        var result = service.getTile("terrain", TileCoordinates.of(10, 100, 200));
         assertInstanceOf(TileService.TileResult.PreRendered.class, result);
         assertNotNull(((TileService.TileResult.PreRendered) result).data());
         assertTrue(((TileService.TileResult.PreRendered) result).data().length > 0);
@@ -49,7 +50,7 @@ class TileServiceTest {
         var service = new TileService(tileDir, layers, new TileResampler(tileDir), new TileCache());
 
         assertThrows(TileService.TileNotFoundException.class,
-                () -> service.getTile("terrain", 10, 100, 200));
+                () -> service.getTile("terrain", TileCoordinates.of(10, 100, 200)));
     }
 
     @Test
@@ -62,7 +63,7 @@ class TileServiceTest {
                 new TileResampler(tileDir), new TileCache());
 
         // Request zoom 11 (no pre-rendered tile, resampled from zoom 10)
-        var result = service.getTile("terrain", 11, 100, 200);
+        var result = service.getTile("terrain", TileCoordinates.of(11, 100, 200));
         assertInstanceOf(TileService.TileResult.Resampled.class, result);
     }
 
@@ -76,12 +77,12 @@ class TileServiceTest {
                 new TileResampler(tileDir), cache);
 
         // First call — cache miss, resamples and stores
-        service.getTile("terrain", 11, 100, 200);
+        service.getTile("terrain", TileCoordinates.of(11, 100, 200));
         assertEquals(0, cache.getHits());
         assertEquals(1, cache.getMisses());
 
         // Second call — cache hit
-        service.getTile("terrain", 11, 100, 200);
+        service.getTile("terrain", TileCoordinates.of(11, 100, 200));
         assertEquals(1, cache.getHits());
         assertEquals(1, cache.getMisses());
     }

--- a/Spec/Plans/GIS-Server-ADR-Compliance-Plan.md
+++ b/Spec/Plans/GIS-Server-ADR-Compliance-Plan.md
@@ -20,7 +20,7 @@ ADR-0005 and ADR-0006 were found not applicable and require no action.
 
 | Phase | ADRs | Description | Tasks | Status |
 |-------|------|-------------|-------|--------|
-| 1 | ADR-0007 | Domain Primitive Consistency | 2 | Not Started |
+| 1 | ADR-0007 | Domain Primitive Consistency | 2 | Done |
 | 2 | ADR-0009 | Package Visibility and ArchUnit | 4 | Not Started |
 | 3 | ADR-0004 | Reverse Proxy Support | 4 | Not Started |
 | 4 | ADR-0002, ADR-0003 | Deployment Infrastructure | 3 | Not Started |
@@ -43,7 +43,7 @@ the service. These two tasks fix that round-trip.
 
 ### Task 1.1 — Change `TileService.getTile()` to accept `TileCoordinates`
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 Replace the three raw `int zoom, int row, int col` parameters with a single
@@ -73,7 +73,7 @@ or pass the individual values separately.
 
 ### Task 1.2 — Update `WmtsController` to pass `TileCoordinates` to the service
 
-**Status:** Not Started
+**Status:** Done
 
 **Description:**
 `WmtsController.handleGetTile` currently creates a `TileCoordinates` instance for


### PR DESCRIPTION
## Summary

- `TileService.getTile()` now accepts `TileCoordinates` instead of three raw `int` parameters (`zoom`, `row`, `col`), completing the domain primitive round-trip required by ADR-0007.
- `WmtsController` now passes the already-created and validated `TileCoordinates` instance directly to the service, eliminating the previous pattern of creating the object for validation only and then discarding it.
- All test call sites updated to use `TileCoordinates.of(...)`.

All 492 tests pass.

## Test plan

- [x] `TileServiceTest` — all 6 tests pass with updated call sites
- [x] `WmtsControllerTest` — all existing tests pass with updated mock setup
- [x] Full GIS Server test suite: 492 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)