### PR TITLE
Add login and logout support to Dispatcher Client

### DIFF
--- a/Implementation/clients/dispatcher-client/.gitignore
+++ b/Implementation/clients/dispatcher-client/.gitignore
@@ -1,0 +1,4 @@
+# Playwright test output
+playwright-report/
+test-results/
+.keycloak-container-id

--- a/Implementation/clients/dispatcher-client/docker/keycloak-realm.json
+++ b/Implementation/clients/dispatcher-client/docker/keycloak-realm.json
@@ -1,0 +1,79 @@
+{
+  "realm": "idispatchx",
+  "enabled": true,
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "clients": [
+    {
+      "clientId": "dispatcher-client",
+      "name": "iDispatchX Dispatcher Client",
+      "description": "OIDC public client for the Dispatcher Client SPA",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "authorizationServicesEnabled": false,
+      "redirectUris": [
+        "http://localhost:5173/*"
+      ],
+      "webOrigins": [
+        "http://localhost:5173"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "protocolMappers": [
+        {
+          "name": "roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "aggregate.attrs": "false"
+          }
+        }
+      ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "Dispatcher",
+        "description": "Full read/write access to Dispatcher Client and its services",
+        "composite": false,
+        "clientRole": false
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "test-dispatcher",
+      "enabled": true,
+      "email": "test-dispatcher@example.com",
+      "firstName": "Test",
+      "lastName": "Dispatcher",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Test1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "Dispatcher"
+      ]
+    }
+  ]
+}

--- a/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
@@ -61,7 +61,7 @@ async function clickSignInAgain(page: Page): Promise<void> {
     await page.evaluate(() => {
         const shell = document.querySelector('idispatch-app-shell');
         const loginScreen = shell?.shadowRoot?.querySelector('idispatch-login-screen');
-        const btn = loginScreen?.shadowRoot?.querySelector('.btn') as HTMLElement | null;
+        const btn = loginScreen?.shadowRoot?.querySelector('.sign-in-button') as HTMLElement | null;
         btn?.click();
     });
 }
@@ -71,7 +71,7 @@ async function getLoginScreenMessage(page: Page): Promise<string> {
     return page.evaluate(() => {
         const shell = document.querySelector('idispatch-app-shell');
         const loginScreen = shell?.shadowRoot?.querySelector('idispatch-login-screen');
-        return loginScreen?.shadowRoot?.querySelector('.message')?.textContent ?? '';
+        return loginScreen?.shadowRoot?.querySelector('.status-message')?.textContent ?? '';
     });
 }
 
@@ -238,7 +238,7 @@ test.describe('Authentication', () => {
         const hasVisibleButton = await page.evaluate(() => {
             const shell = document.querySelector('idispatch-app-shell');
             const loginScreen = shell?.shadowRoot?.querySelector('idispatch-login-screen');
-            const btn = loginScreen?.shadowRoot?.querySelector('.btn') as HTMLElement | null;
+            const btn = loginScreen?.shadowRoot?.querySelector('.sign-in-button') as HTMLElement | null;
             return btn !== null && btn.style.display !== 'none';
         });
         expect(hasVisibleButton).toBe(true);

--- a/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
@@ -262,4 +262,91 @@ test.describe('Authentication', () => {
         await expectAuthenticated(page);
     });
 
+    // -----------------------------------------------------------------------
+    // Regression tests for second review pass
+    // -----------------------------------------------------------------------
+
+    test('failed bootstrap refresh clears stale login timestamp for new session', async ({ page }) => {
+        // Regression for: #tryRefresh only removed KEY_REFRESH_TOKEN on failure,
+        // leaving KEY_LOGIN_AT intact. A fresh login following a stale refresh token
+        // then inherited the old timestamp, making max-lifetime checks fire immediately
+        // or shorten the brand-new session by the age of the prior one.
+        //
+        // We prime sessionStorage on the first load with a login_at 8 hours in the
+        // past and a deliberately invalid refresh token. The app tries the bootstrap
+        // refresh, fails, then starts a fresh PKCE login. After that login completes
+        // the stored login_at must reflect the new session, not the stale one.
+        //
+        // The guard key prevents the init script from re-seeding the stale values
+        // when the browser returns to this origin after the Keycloak redirect.
+        await page.addInitScript(() => {
+            if (sessionStorage.getItem('__test_prime') === null) {
+                sessionStorage.setItem('__test_prime', '1');
+                sessionStorage.setItem('idispatchx.login_at', String(Date.now() - 8 * 60 * 60 * 1000));
+                sessionStorage.setItem('idispatchx.refresh_token', 'deliberately-stale-invalid-token');
+            }
+        });
+
+        await loginViaKeycloak(page);
+        await expectAuthenticated(page);
+
+        const loginAt = await page.evaluate(() =>
+            Number(sessionStorage.getItem('idispatchx.login_at') ?? '0')
+        );
+        const ageMs = Date.now() - loginAt;
+        // login_at must reflect the new session (< 30 s old), not the stale one (8 h).
+        expect(ageMs).toBeLessThan(30_000);
+    });
+
+    test('access token refresh preserves stored refresh token when provider omits rotation', async ({ page }) => {
+        // Regression for: #applyTokenResponse unconditionally removed the stored
+        // refresh token when the token response omitted refresh_token. Providers that
+        // keep the original token valid without rotating it (a valid OAuth/OIDC
+        // behaviour) would therefore cause the next refresh cycle to call forceLogout.
+        //
+        // We intercept the token endpoint for refresh_token grants and strip
+        // refresh_token from the response body, simulating a non-rotating provider.
+        // After the refresh completes the original token must still be in storage.
+        await loginViaKeycloak(page);
+        await expectAuthenticated(page);
+
+        const tokenBefore = await page.evaluate(() =>
+            sessionStorage.getItem('idispatchx.refresh_token')
+        );
+        expect(tokenBefore).not.toBeNull();
+
+        // Strip refresh_token from refresh responses only (leave code-exchange alone).
+        await page.route('**/realms/idispatchx/protocol/openid-connect/token', async route => {
+            const body = route.request().postData() ?? '';
+            if (body.includes('grant_type=refresh_token')) {
+                const response = await route.fetch();
+                const json = await response.json() as Record<string, unknown>;
+                delete json['refresh_token'];
+                await route.fulfill({
+                    status: response.status(),
+                    headers: response.headers(),
+                    body: JSON.stringify(json),
+                });
+            } else {
+                await route.continue();
+            }
+        });
+
+        // Trigger an explicit refresh and wait for the app to remain authenticated.
+        await page.evaluate(() => {
+            const w = window as Window & { __authState?: { refresh(): Promise<void> } };
+            return w.__authState?.refresh();
+        });
+        await page.waitForFunction(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            return !!shell?.shadowRoot?.querySelector('.app-content');
+        }, { timeout: 5_000 });
+
+        // The original refresh token must still be present — it was not rotated.
+        const tokenAfter = await page.evaluate(() =>
+            sessionStorage.getItem('idispatchx.refresh_token')
+        );
+        expect(tokenAfter).toBe(tokenBefore);
+    });
+
 });

--- a/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
@@ -1,0 +1,219 @@
+// E2E tests for Dispatcher Client login and logout flows.
+// Keycloak runs on port 8180 (started by globalSetup.ts).
+// Vite dev server runs on port 5173 with VITE_CONFIG_URL=/config.test.json.
+
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+const APP_URL = 'http://localhost:5173/';
+const KEYCLOAK_ORIGIN = 'http://localhost:8180';
+
+// Keycloak test user credentials
+const TEST_USER = 'test-dispatcher';
+const TEST_PASSWORD = 'Test1234!';
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+/** Navigates to the app and fills in Keycloak credentials to complete login. */
+async function loginViaKeycloak(page: Page, username = TEST_USER, password = TEST_PASSWORD): Promise<void> {
+    await page.goto(APP_URL);
+
+    // App redirects to Keycloak
+    await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 10_000 });
+
+    // Fill in credentials on Keycloak's login page
+    await page.fill('input[name="username"]', username);
+    await page.fill('input[name="password"]', password);
+    await page.click('input[type="submit"], button[type="submit"]');
+}
+
+/**
+ * Waits for the app to be in an authenticated state.
+ * Checks the AppShell's shadow DOM for the .app-content placeholder via page.waitForFunction,
+ * which is the most reliable way to cross shadow DOM boundaries.
+ */
+async function expectAuthenticated(page: Page): Promise<void> {
+    await page.waitForURL(APP_URL, { timeout: 10_000 });
+    await page.waitForFunction(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        return !!shell?.shadowRoot?.querySelector('.app-content');
+    }, { timeout: 8_000 });
+}
+
+/**
+ * Waits for the login screen with the given status to appear inside AppShell's shadow DOM.
+ */
+async function expectLoginScreen(page: Page, status?: string): Promise<void> {
+    await page.waitForFunction((expectedStatus: string | undefined) => {
+        const shell = document.querySelector('idispatch-app-shell');
+        if (!shell?.shadowRoot) return false;
+        const loginScreen = shell.shadowRoot.querySelector('idispatch-login-screen');
+        if (!loginScreen) return false;
+        if (expectedStatus && loginScreen.getAttribute('status') !== expectedStatus) return false;
+        return true;
+    }, status, { timeout: 8_000 });
+}
+
+/** Clicks the "Sign in again" button inside LoginScreen's shadow DOM. */
+async function clickSignInAgain(page: Page): Promise<void> {
+    await page.evaluate(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        const loginScreen = shell?.shadowRoot?.querySelector('idispatch-login-screen');
+        const btn = loginScreen?.shadowRoot?.querySelector('.btn') as HTMLElement | null;
+        btn?.click();
+    });
+}
+
+/** Gets the message text from LoginScreen's shadow DOM. */
+async function getLoginScreenMessage(page: Page): Promise<string> {
+    return page.evaluate(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        const loginScreen = shell?.shadowRoot?.querySelector('idispatch-login-screen');
+        return loginScreen?.shadowRoot?.querySelector('.message')?.textContent ?? '';
+    });
+}
+
+/** Waits for window.__authState to be available, then calls forceLogout. */
+async function simulateForceLogout(page: Page, reason: string): Promise<void> {
+    await page.waitForFunction(() => {
+        return !!(window as Window & { __authState?: unknown }).__authState;
+    }, { timeout: 5_000 });
+    await page.evaluate((r: string) => {
+        const w = window as Window & { __authState?: { forceLogout(reason: string): void } };
+        w.__authState?.forceLogout(r);
+    }, reason);
+}
+
+// -------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------
+
+test.describe('Authentication', () => {
+
+    test('redirects unauthenticated user to Keycloak login page', async ({ page }) => {
+        await page.context().clearCookies();
+
+        await page.goto(APP_URL);
+
+        // App should redirect to Keycloak
+        await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 10_000 });
+
+        // Keycloak login form should be present
+        await expect(page.locator('input[name="username"]')).toBeVisible();
+        await expect(page.locator('input[name="password"]')).toBeVisible();
+    });
+
+    test('shows loading screen while auth is in progress', async ({ page }) => {
+        // The app shows the AppShell (loading state) before redirecting to Keycloak
+        let sawKeycloakRequest = false;
+        page.on('request', req => {
+            if (req.url().startsWith(KEYCLOAK_ORIGIN)) {
+                sawKeycloakRequest = true;
+            }
+        });
+
+        await page.goto(APP_URL);
+        await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 10_000 });
+
+        expect(sawKeycloakRequest).toBe(true);
+    });
+
+    test('login with valid credentials returns to app in authenticated state', async ({ page }) => {
+        await loginViaKeycloak(page);
+        await expectAuthenticated(page);
+    });
+
+    test('login with wrong password shows Keycloak error and does not redirect to app', async ({ page }) => {
+        await loginViaKeycloak(page, TEST_USER, 'wrong-password');
+
+        // Should remain on Keycloak (URL starts with KEYCLOAK_ORIGIN after submit)
+        await expect(page).toHaveURL(new RegExp(KEYCLOAK_ORIGIN.replace(/\./g, '\\.')));
+
+        // Keycloak shows an error message for invalid credentials
+        const errorEl = page.getByText(/invalid username or password/i);
+        await expect(errorEl.first()).toBeVisible({ timeout: 5_000 });
+    });
+
+    test('logout clears session and redirects back to login page', async ({ page }) => {
+        // Login first
+        await loginViaKeycloak(page);
+        await expectAuthenticated(page);
+
+        // Trigger logout via the exposed __authState handle (DEV mode only)
+        await page.waitForFunction(() => {
+            return !!(window as Window & { __authState?: unknown }).__authState;
+        }, { timeout: 5_000 });
+        await page.evaluate(() => {
+            const w = window as Window & { __authState?: { logout(): Promise<void> } };
+            return w.__authState?.logout();
+        });
+
+        // After RP-initiated logout, Keycloak redirects to post_logout_redirect_uri (the app),
+        // which then has no session and redirects back to Keycloak login page.
+        await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 15_000 });
+        await expect(page.locator('input[name="username"]')).toBeVisible();
+    });
+
+    test('forced session termination (simulated 401) shows session-expired screen', async ({ page }) => {
+        await loginViaKeycloak(page);
+        await expectAuthenticated(page);
+
+        // Simulate server-side session revocation (what happens when CAD Server
+        // invalidates the session and the next request returns HTTP 401)
+        await simulateForceLogout(page, 'forced-logout');
+
+        // Login screen should appear with session-expired status
+        await expectLoginScreen(page, 'forced-logout');
+    });
+
+    test('idle timeout shows idle-timeout screen', async ({ page }) => {
+        await loginViaKeycloak(page);
+        await expectAuthenticated(page);
+
+        // Simulate idle timeout
+        await simulateForceLogout(page, 'idle-timeout');
+
+        await expectLoginScreen(page, 'idle-timeout');
+
+        // Message should mention inactivity
+        const message = await getLoginScreenMessage(page);
+        expect(message).toContain('inactivity');
+    });
+
+    test('PKCE callback with mismatched state is safely rejected and triggers fresh login', async ({ page }) => {
+        // Navigate to the app — this starts the PKCE flow and stores the real state
+        // in sessionStorage, then redirects to Keycloak
+        await page.goto(APP_URL);
+        await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 10_000 });
+
+        // Navigate back with a fake code and mismatched state.
+        // The app should detect the mismatch, discard the callback, and
+        // start a fresh PKCE redirect (back to Keycloak).
+        await page.goto(`${APP_URL}?code=fake-code&state=deliberately-wrong-state`);
+
+        // App detects mismatch → starts fresh PKCE flow → redirects to Keycloak
+        await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 10_000 });
+        await expect(page.locator('input[name="username"]')).toBeVisible();
+    });
+
+    test('sign-in-again button after session expiry restarts login flow', async ({ page }) => {
+        await loginViaKeycloak(page);
+        await expectAuthenticated(page);
+
+        // Force a local session expiry (clears local tokens but does NOT end the
+        // Keycloak SSO session — this matches the server-revocation scenario).
+        await simulateForceLogout(page, 'forced-logout');
+        await expectLoginScreen(page, 'forced-logout');
+
+        // Click "Sign in again" — restarts the OIDC Authorization Code + PKCE flow.
+        await clickSignInAgain(page);
+
+        // Because the Keycloak SSO session is still active, the authorization code
+        // flow completes silently (no login form shown). The user lands back on the app
+        // already authenticated — this is the expected SSO re-authentication behavior.
+        await expectAuthenticated(page);
+    });
+
+});

--- a/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
@@ -198,6 +198,52 @@ test.describe('Authentication', () => {
         await expect(page.locator('input[name="username"]')).toBeVisible();
     });
 
+    // -----------------------------------------------------------------------
+    // Regression tests for review comments
+    // -----------------------------------------------------------------------
+
+    test('forced-logout screen shows a "signed out" message, not the loading spinner message', async ({ page }) => {
+        // Regression for: AppShell sets status="forced-logout" on LoginScreen, but
+        // LoginScreen only handled 'loading', 'session-expired', 'idle-timeout', and
+        // 'max-lifetime'. The 'forced-logout' value fell through to the STATUS_MESSAGES
+        // fallback, showing "Signing in…" instead of a meaningful sign-out message.
+        await loginViaKeycloak(page);
+        await expectAuthenticated(page);
+
+        await simulateForceLogout(page, 'forced-logout');
+        await expectLoginScreen(page, 'forced-logout');
+
+        const message = await getLoginScreenMessage(page);
+        expect(message).not.toContain('Signing in');
+        expect(message.toLowerCase()).toContain('signed out');
+    });
+
+    test('OIDC discovery failure shows a recoverable error screen with a retry button', async ({ page }) => {
+        // Regression for: when OIDC discovery threw, AuthState emitted
+        // { kind: 'unauthenticated' }, which rendered the "loading" screen
+        // (spinner, no button). Users were permanently stuck with no in-app
+        // recovery path. The fix must emit a recoverable state so the "Sign in
+        // again" button appears.
+        await page.route(
+            `**/realms/idispatchx/.well-known/openid-configuration`,
+            route => route.fulfill({ status: 500, body: 'Internal Server Error' }),
+        );
+
+        await page.goto(APP_URL);
+
+        // A login screen must appear (not just a loading spinner forever)
+        await expectLoginScreen(page);
+
+        // The "Sign in again" button must be visible — not hidden behind a spinner
+        const hasVisibleButton = await page.evaluate(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const loginScreen = shell?.shadowRoot?.querySelector('idispatch-login-screen');
+            const btn = loginScreen?.shadowRoot?.querySelector('.btn') as HTMLElement | null;
+            return btn !== null && btn.style.display !== 'none';
+        });
+        expect(hasVisibleButton).toBe(true);
+    });
+
     test('sign-in-again button after session expiry restarts login flow', async ({ page }) => {
         await loginViaKeycloak(page);
         await expectAuthenticated(page);

--- a/Implementation/clients/dispatcher-client/e2e/globalSetup.ts
+++ b/Implementation/clients/dispatcher-client/e2e/globalSetup.ts
@@ -1,0 +1,85 @@
+// Playwright global setup: starts a Keycloak Docker container for E2E tests.
+// The container ID is written to a temp file so globalTeardown can stop it.
+
+import { execSync, spawnSync } from 'child_process';
+import { writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+
+const KEYCLOAK_IMAGE = 'quay.io/keycloak/keycloak:26.0.0';
+const KEYCLOAK_PORT = 8180;
+const CONTAINER_NAME = 'idispatchx-keycloak-test';
+const CONTAINER_ID_FILE = join(process.cwd(), '.keycloak-container-id');
+const STARTUP_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 2_000;
+
+export default async function globalSetup(): Promise<void> {
+    console.log('\n[E2E Setup] Starting Keycloak...');
+
+    // Stop any leftover container from a previous run
+    stopExistingContainer();
+
+    const realmJsonPath = resolve(process.cwd(), 'docker/keycloak-realm.json');
+
+    // Start Keycloak with realm import
+    const result = spawnSync('docker', [
+        'run', '--detach',
+        '--name', CONTAINER_NAME,
+        '-p', `${KEYCLOAK_PORT}:8080`,
+        '-e', 'KEYCLOAK_ADMIN=admin',
+        '-e', 'KEYCLOAK_ADMIN_PASSWORD=admin',
+        '-e', 'KC_HEALTH_ENABLED=true',
+        '-v', `${realmJsonPath}:/opt/keycloak/data/import/realm.json`,
+        KEYCLOAK_IMAGE,
+        'start-dev', '--import-realm',
+    ], { encoding: 'utf8' });
+
+    if (result.status !== 0) {
+        throw new Error(`Failed to start Keycloak container: ${result.stderr}`);
+    }
+
+    const containerId = result.stdout.trim();
+    writeFileSync(CONTAINER_ID_FILE, containerId);
+
+    console.log(`[E2E Setup] Keycloak container started: ${containerId.slice(0, 12)}`);
+    console.log(`[E2E Setup] Waiting for Keycloak to be ready on port ${KEYCLOAK_PORT}...`);
+
+    await waitForKeycloak();
+    console.log('[E2E Setup] Keycloak is ready.\n');
+}
+
+function stopExistingContainer(): void {
+    try {
+        execSync(`docker stop ${CONTAINER_NAME} 2>/dev/null; docker rm ${CONTAINER_NAME} 2>/dev/null`, {
+            stdio: 'ignore',
+        });
+    } catch {
+        // Ignore errors — container may not exist
+    }
+}
+
+async function waitForKeycloak(): Promise<void> {
+    // Poll the OIDC discovery endpoint on the main port — this confirms both that
+    // Keycloak is running AND that the test realm has been imported successfully.
+    // (The management health endpoint is on port 9000 and is not exposed.)
+    const healthUrl = `http://localhost:${KEYCLOAK_PORT}/realms/idispatchx/.well-known/openid-configuration`;
+    const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+        try {
+            const response = await fetch(healthUrl);
+            if (response.ok) return;
+        } catch {
+            // Not ready yet
+        }
+        await sleep(POLL_INTERVAL_MS);
+    }
+
+    throw new Error(
+        `Keycloak did not become ready within ${STARTUP_TIMEOUT_MS / 1000}s. ` +
+        `Check 'docker logs ${CONTAINER_NAME}' for details.`
+    );
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/Implementation/clients/dispatcher-client/e2e/globalTeardown.ts
+++ b/Implementation/clients/dispatcher-client/e2e/globalTeardown.ts
@@ -1,0 +1,32 @@
+// Playwright global teardown: stops and removes the Keycloak Docker container.
+
+import { execSync } from 'child_process';
+import { readFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+
+const CONTAINER_ID_FILE = join(process.cwd(), '.keycloak-container-id');
+
+export default function globalTeardown(): void {
+    console.log('\n[E2E Teardown] Stopping Keycloak...');
+
+    let containerId: string | null = null;
+    try {
+        containerId = readFileSync(CONTAINER_ID_FILE, 'utf8').trim();
+        unlinkSync(CONTAINER_ID_FILE);
+    } catch {
+        // Container ID file missing — container may have already been removed
+    }
+
+    try {
+        if (containerId) {
+            execSync(`docker stop ${containerId} && docker rm ${containerId}`, { stdio: 'ignore' });
+        } else {
+            execSync('docker stop idispatchx-keycloak-test && docker rm idispatchx-keycloak-test', {
+                stdio: 'ignore',
+            });
+        }
+        console.log('[E2E Teardown] Keycloak stopped.\n');
+    } catch {
+        console.warn('[E2E Teardown] Warning: could not stop Keycloak container (may already be stopped).');
+    }
+}

--- a/Implementation/clients/dispatcher-client/e2e/tsconfig.json
+++ b/Implementation/clients/dispatcher-client/e2e/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": []
+}

--- a/Implementation/clients/dispatcher-client/package-lock.json
+++ b/Implementation/clients/dispatcher-client/package-lock.json
@@ -11,6 +11,7 @@
         "ol": "10.7.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "typescript": "5.9.3",
         "vite": "7.3.1"
       }
@@ -462,6 +463,22 @@
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -1005,12 +1022,58 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/Implementation/clients/dispatcher-client/package.json
+++ b/Implementation/clients/dispatcher-client/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "typescript": "5.9.3",
     "vite": "7.3.1"
   },

--- a/Implementation/clients/dispatcher-client/playwright.config.ts
+++ b/Implementation/clients/dispatcher-client/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: 'e2e',
+    testMatch: '**/*.spec.ts',
+
+    // Run tests sequentially — OIDC state is shared via sessionStorage
+    workers: 1,
+    fullyParallel: false,
+
+    // Retry once on failure in CI to handle transient timing issues
+    retries: process.env['CI'] ? 1 : 0,
+
+    reporter: [['list'], ['html', { open: 'never' }]],
+
+    use: {
+        baseURL: 'http://localhost:5173',
+        // Capture traces on first retry only (saves disk space)
+        trace: 'on-first-retry',
+        // Give ample time for Keycloak redirects
+        navigationTimeout: 15_000,
+        actionTimeout: 10_000,
+    },
+
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+
+    // Start the Vite dev server with the test config URL before running tests
+    webServer: {
+        command: 'npm run dev',
+        url: 'http://localhost:5173',
+        reuseExistingServer: !process.env['CI'],
+        timeout: 30_000,
+        env: {
+            // Tells AppConfig to load /config.test.json instead of /config.json
+            VITE_CONFIG_URL: '/config.test.json',
+        },
+    },
+
+    globalSetup: './e2e/globalSetup.ts',
+    globalTeardown: './e2e/globalTeardown.ts',
+});

--- a/Implementation/clients/dispatcher-client/src/auth/AuthState.ts
+++ b/Implementation/clients/dispatcher-client/src/auth/AuthState.ts
@@ -1,0 +1,303 @@
+// Central auth state machine for the Dispatcher Client.
+// Holds the access token in memory only. Orchestrates the OIDC boot flow,
+// schedules token refresh, and emits AuthChangedEvent to subscribers.
+
+import type { AppConfig } from '../config/AppConfig.ts';
+import type { OidcDiscovery, PkceSession, TokenResponse, TokenSet } from './types.ts';
+import type { AuthStatus } from './types.ts';
+import { OidcClient } from './OidcClient.ts';
+
+// sessionStorage key constants
+const KEY_REFRESH_TOKEN = 'idispatchx.refresh_token';
+const KEY_ID_TOKEN = 'idispatchx.id_token';
+const KEY_LOGIN_AT = 'idispatchx.login_at';
+const KEY_PKCE = 'idispatchx.pkce';
+const KEY_DISCOVERY = 'idispatchx.oidc_discovery';
+
+/** Maximum age for a cached OIDC discovery document (10 minutes). */
+const DISCOVERY_CACHE_TTL_MS = 10 * 60 * 1000;
+
+/** Refresh the access token this many seconds before it expires. */
+const REFRESH_BEFORE_EXPIRY_S = 60;
+
+/** Custom event emitted whenever auth status changes. */
+export class AuthChangedEvent extends CustomEvent<AuthStatus> {
+    static readonly TYPE = 'auth-changed' as const;
+
+    constructor(status: AuthStatus) {
+        super(AuthChangedEvent.TYPE, { detail: status, bubbles: false });
+    }
+}
+
+/** Emitted when the session is within 5 minutes of expiring (idle or max-lifetime). */
+export class SessionWarningEvent extends CustomEvent<{ reason: 'idle-timeout' | 'max-lifetime'; secondsRemaining: number }> {
+    static readonly TYPE = 'session-warning' as const;
+
+    constructor(reason: 'idle-timeout' | 'max-lifetime', secondsRemaining: number) {
+        super(SessionWarningEvent.TYPE, { detail: { reason, secondsRemaining }, bubbles: false });
+    }
+}
+
+export class AuthState extends EventTarget {
+    // Access token is NEVER written to storage — memory only.
+    #accessToken: string | null = null;
+    #status: AuthStatus = { kind: 'unauthenticated' };
+    #discovery: OidcDiscovery | null = null;
+    #refreshTimerId: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(
+        private readonly client: OidcClient,
+        private readonly config: AppConfig,
+    ) {
+        super();
+    }
+
+    /**
+     * Boot sequence. Called once by main.ts.
+     * 1. Load/cache OIDC discovery.
+     * 2. If ?code= in URL: exchange code (PKCE callback).
+     * 3. Else if refresh token in sessionStorage: try refresh.
+     * 4. Else: start PKCE redirect to OIDC provider.
+     */
+    async initialize(): Promise<void> {
+        this.#emit({ kind: 'authenticating' });
+
+        try {
+            this.#discovery = await this.#loadDiscovery();
+        } catch (err) {
+            console.error('[AuthState] OIDC discovery failed:', err);
+            this.#emit({ kind: 'unauthenticated' });
+            return;
+        }
+
+        const params = new URL(window.location.href).searchParams;
+        const code = params.get('code');
+        const returnedState = params.get('state');
+
+        if (code !== null) {
+            await this.#handleCallback(code, returnedState);
+            return;
+        }
+
+        const storedRefreshToken = sessionStorage.getItem(KEY_REFRESH_TOKEN);
+        if (storedRefreshToken !== null) {
+            const refreshed = await this.#tryRefresh(storedRefreshToken);
+            if (refreshed) return;
+        }
+
+        // No code, no usable refresh token → start PKCE flow
+        await this.#startPkceRedirect();
+    }
+
+    /** Returns the current auth status snapshot (synchronous). */
+    getStatus(): AuthStatus {
+        return this.#status;
+    }
+
+    /** Returns the in-memory access token, or null if not authenticated. */
+    getAccessToken(): string | null {
+        return this.#accessToken;
+    }
+
+    /** Returns the cached discovery document, or null before initialize(). */
+    getDiscovery(): OidcDiscovery | null {
+        return this.#discovery;
+    }
+
+    /**
+     * Triggers an explicit refresh (e.g. called by refresh timer).
+     * On failure, treats the session as force-expired.
+     */
+    async refresh(): Promise<void> {
+        const refreshToken = sessionStorage.getItem(KEY_REFRESH_TOKEN);
+        if (!refreshToken || !this.#discovery) {
+            this.forceLogout('forced-logout');
+            return;
+        }
+
+        const refreshed = await this.#tryRefresh(refreshToken);
+        if (!refreshed) {
+            this.forceLogout('forced-logout');
+        }
+    }
+
+    /**
+     * Explicit user-initiated logout.
+     * Clears all tokens, then redirects to the OIDC end_session_endpoint.
+     */
+    async logout(): Promise<void> {
+        const idToken = sessionStorage.getItem(KEY_ID_TOKEN);
+        this.#clearTokens();
+        this.#emit({ kind: 'unauthenticated' });
+
+        if (this.#discovery) {
+            const url = this.client.buildLogoutUrl(this.#discovery, idToken);
+            window.location.href = url;
+        } else {
+            window.location.href = this.config.oidc.postLogoutRedirectUri;
+        }
+    }
+
+    /**
+     * Called by SessionManager or HttpClient on timeout/401.
+     * Clears tokens and emits an expired event, but does NOT redirect immediately —
+     * AppShell shows the overlay first, then redirects on "login-requested".
+     */
+    forceLogout(reason: 'idle-timeout' | 'max-lifetime' | 'forced-logout'): void {
+        this.#clearTokens();
+        this.#emit({ kind: 'expired', reason });
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    async #loadDiscovery(): Promise<OidcDiscovery> {
+        const cached = sessionStorage.getItem(KEY_DISCOVERY);
+        if (cached !== null) {
+            try {
+                const parsed = JSON.parse(cached) as { issuer: string; doc: OidcDiscovery; cachedAt: number };
+                const age = Date.now() - parsed.cachedAt;
+                if (parsed.issuer === this.config.oidc.issuer && age < DISCOVERY_CACHE_TTL_MS) {
+                    return parsed.doc;
+                }
+            } catch {
+                // Corrupt cache — ignore and re-fetch
+            }
+        }
+
+        const doc = await this.client.discover();
+        sessionStorage.setItem(KEY_DISCOVERY, JSON.stringify({
+            issuer: this.config.oidc.issuer,
+            doc,
+            cachedAt: Date.now(),
+        }));
+        return doc;
+    }
+
+    async #handleCallback(code: string, returnedState: string | null): Promise<void> {
+        const pkceRaw = sessionStorage.getItem(KEY_PKCE);
+        sessionStorage.removeItem(KEY_PKCE);
+
+        // Clean the callback params from the browser URL immediately
+        history.replaceState(null, '', window.location.pathname);
+
+        if (pkceRaw === null) {
+            // No PKCE session found — the callback URL is stale or the user
+            // navigated directly to a callback URL. Start a fresh login flow.
+            console.warn('[AuthState] No PKCE session in storage; starting fresh login flow');
+            await this.#startPkceRedirect();
+            return;
+        }
+
+        let pkce: PkceSession;
+        try {
+            pkce = JSON.parse(pkceRaw) as PkceSession;
+        } catch {
+            console.warn('[AuthState] Corrupt PKCE session data; starting fresh login flow');
+            await this.#startPkceRedirect();
+            return;
+        }
+
+        // CSRF check: the state returned in the callback must match the stored nonce.
+        if (returnedState !== pkce.state) {
+            console.error('[AuthState] PKCE state mismatch — possible CSRF; discarding callback and starting fresh login flow');
+            await this.#startPkceRedirect();
+            return;
+        }
+
+        try {
+            const tokenResponse = await this.client.exchangeCode(this.#discovery!, code, pkce);
+            this.#applyTokenResponse(tokenResponse);
+        } catch (err) {
+            console.error('[AuthState] Code exchange failed:', err);
+            // Show an error screen that lets the user retry
+            this.#emit({ kind: 'expired', reason: 'forced-logout' });
+        }
+    }
+
+    async #tryRefresh(refreshToken: string): Promise<boolean> {
+        try {
+            const tokenResponse = await this.client.refreshTokens(this.#discovery!, refreshToken);
+            this.#applyTokenResponse(tokenResponse);
+            return true;
+        } catch (err) {
+            console.warn('[AuthState] Token refresh failed:', err);
+            sessionStorage.removeItem(KEY_REFRESH_TOKEN);
+            return false;
+        }
+    }
+
+    async #startPkceRedirect(): Promise<void> {
+        const pkce: PkceSession = {
+            codeVerifier: this.client.generateCodeVerifier(),
+            state: this.client.generateState(),
+            startedAt: Date.now(),
+        };
+        sessionStorage.setItem(KEY_PKCE, JSON.stringify(pkce));
+
+        const authUrl = await this.client.buildAuthUrl(this.#discovery!, pkce);
+        window.location.href = authUrl;
+    }
+
+    #applyTokenResponse(response: TokenResponse): void {
+        const parsed = this.client.parseToken(response.access_token);
+        const expiresAt = Date.now() + response.expires_in * 1000;
+
+        this.#accessToken = response.access_token;
+
+        const tokenSet: TokenSet = {
+            accessToken: response.access_token,
+            idToken: response.id_token ?? null,
+            refreshToken: response.refresh_token ?? null,
+            expiresAt,
+            parsedAccess: parsed,
+        };
+
+        // Persist refresh token and id token to sessionStorage for page refreshes
+        if (response.refresh_token) {
+            sessionStorage.setItem(KEY_REFRESH_TOKEN, response.refresh_token);
+        } else {
+            sessionStorage.removeItem(KEY_REFRESH_TOKEN);
+        }
+
+        if (response.id_token) {
+            sessionStorage.setItem(KEY_ID_TOKEN, response.id_token);
+        }
+
+        // Record login time only on first authentication (not on refresh)
+        if (sessionStorage.getItem(KEY_LOGIN_AT) === null) {
+            sessionStorage.setItem(KEY_LOGIN_AT, String(Date.now()));
+        }
+
+        this.#scheduleRefresh(response.expires_in);
+        this.#emit({ kind: 'authenticated', tokenSet });
+    }
+
+    #scheduleRefresh(expiresInSeconds: number): void {
+        if (this.#refreshTimerId !== null) {
+            clearTimeout(this.#refreshTimerId);
+        }
+        const delayMs = Math.max(0, (expiresInSeconds - REFRESH_BEFORE_EXPIRY_S) * 1000);
+        this.#refreshTimerId = setTimeout(() => {
+            void this.refresh();
+        }, delayMs);
+    }
+
+    #clearTokens(): void {
+        if (this.#refreshTimerId !== null) {
+            clearTimeout(this.#refreshTimerId);
+            this.#refreshTimerId = null;
+        }
+        this.#accessToken = null;
+        sessionStorage.removeItem(KEY_REFRESH_TOKEN);
+        sessionStorage.removeItem(KEY_ID_TOKEN);
+        sessionStorage.removeItem(KEY_LOGIN_AT);
+        sessionStorage.removeItem(KEY_PKCE);
+    }
+
+    #emit(status: AuthStatus): void {
+        this.#status = status;
+        this.dispatchEvent(new AuthChangedEvent(status));
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/auth/AuthState.ts
+++ b/Implementation/clients/dispatcher-client/src/auth/AuthState.ts
@@ -66,7 +66,10 @@ export class AuthState extends EventTarget {
             this.#discovery = await this.#loadDiscovery();
         } catch (err) {
             console.error('[AuthState] OIDC discovery failed:', err);
-            this.#emit({ kind: 'unauthenticated' });
+            // Emit a recoverable expired state so AppShell shows the login screen
+            // with a "Sign in again" button. Emitting 'unauthenticated' here would
+            // render the indefinite loading spinner, leaving users with no retry path.
+            this.#emit({ kind: 'expired', reason: 'forced-logout' });
             return;
         }
 

--- a/Implementation/clients/dispatcher-client/src/auth/AuthState.ts
+++ b/Implementation/clients/dispatcher-client/src/auth/AuthState.ts
@@ -227,6 +227,9 @@ export class AuthState extends EventTarget {
         } catch (err) {
             console.warn('[AuthState] Token refresh failed:', err);
             sessionStorage.removeItem(KEY_REFRESH_TOKEN);
+            // Clear login timestamp so a fresh login after a stale refresh token
+            // starts its own max-lifetime clock from zero, not from the prior session.
+            sessionStorage.removeItem(KEY_LOGIN_AT);
             return false;
         }
     }
@@ -257,11 +260,12 @@ export class AuthState extends EventTarget {
             parsedAccess: parsed,
         };
 
-        // Persist refresh token and id token to sessionStorage for page refreshes
+        // Persist refresh token and id token to sessionStorage for page refreshes.
+        // Only overwrite the stored refresh token when the provider returns a new one
+        // (i.e. token rotation). If the response omits refresh_token the provider is
+        // keeping the original valid, so the existing stored token must be preserved.
         if (response.refresh_token) {
             sessionStorage.setItem(KEY_REFRESH_TOKEN, response.refresh_token);
-        } else {
-            sessionStorage.removeItem(KEY_REFRESH_TOKEN);
         }
 
         if (response.id_token) {

--- a/Implementation/clients/dispatcher-client/src/auth/OidcClient.ts
+++ b/Implementation/clients/dispatcher-client/src/auth/OidcClient.ts
@@ -1,0 +1,230 @@
+// Stateless OIDC / PKCE mechanics for the Dispatcher Client.
+// All state is managed by AuthState; this class only handles network calls
+// and cryptographic operations.
+
+import type { OidcConfig } from '../config/AppConfig.ts';
+import type { OidcDiscovery, ParsedToken, PkceSession, TokenResponse } from './types.ts';
+
+export class OidcClient {
+    constructor(private readonly config: OidcConfig) {}
+
+    /**
+     * Fetches and parses the OIDC discovery document.
+     * Constructs the URL as {issuer}/.well-known/openid-configuration per the spec.
+     */
+    async discover(): Promise<OidcDiscovery> {
+        const url = `${this.config.issuer}/.well-known/openid-configuration`;
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`OIDC discovery failed: HTTP ${response.status} from ${url}`);
+        }
+        const doc = await response.json() as Record<string, unknown>;
+
+        if (typeof doc['authorization_endpoint'] !== 'string') {
+            throw new Error('OIDC discovery document missing authorization_endpoint');
+        }
+        if (typeof doc['token_endpoint'] !== 'string') {
+            throw new Error('OIDC discovery document missing token_endpoint');
+        }
+        if (typeof doc['jwks_uri'] !== 'string') {
+            throw new Error('OIDC discovery document missing jwks_uri');
+        }
+
+        return {
+            issuer: typeof doc['issuer'] === 'string' ? doc['issuer'] : this.config.issuer,
+            authorization_endpoint: doc['authorization_endpoint'] as string,
+            token_endpoint: doc['token_endpoint'] as string,
+            end_session_endpoint: typeof doc['end_session_endpoint'] === 'string'
+                ? doc['end_session_endpoint']
+                : undefined,
+            jwks_uri: doc['jwks_uri'] as string,
+        };
+    }
+
+    /**
+     * Generates a cryptographically random PKCE code verifier.
+     * Uses 32 random bytes encoded as base64url per RFC 7636.
+     */
+    generateCodeVerifier(): string {
+        const array = new Uint8Array(32);
+        crypto.getRandomValues(array);
+        return base64urlEncode(array);
+    }
+
+    /**
+     * Derives the PKCE code challenge from the verifier using the S256 method.
+     * SHA-256 hash of the verifier, base64url-encoded.
+     */
+    async generateCodeChallenge(verifier: string): Promise<string> {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(verifier);
+        const digest = await crypto.subtle.digest('SHA-256', data);
+        return base64urlEncode(new Uint8Array(digest));
+    }
+
+    /** Generates a random state nonce for CSRF protection. */
+    generateState(): string {
+        const array = new Uint8Array(16);
+        crypto.getRandomValues(array);
+        return base64urlEncode(array);
+    }
+
+    /**
+     * Builds the full authorization URL to redirect the browser to.
+     * Includes PKCE challenge and state nonce.
+     */
+    async buildAuthUrl(discovery: OidcDiscovery, pkceSession: PkceSession): Promise<string> {
+        const challenge = await this.generateCodeChallenge(pkceSession.codeVerifier);
+        const params = new URLSearchParams({
+            response_type: 'code',
+            client_id: this.config.clientId,
+            redirect_uri: this.config.redirectUri,
+            scope: this.config.scopes.join(' '),
+            state: pkceSession.state,
+            code_challenge: challenge,
+            code_challenge_method: 'S256',
+        });
+        return `${discovery.authorization_endpoint}?${params.toString()}`;
+    }
+
+    /**
+     * Exchanges the authorization code for tokens at the token endpoint.
+     * POSTs with code, code_verifier, and redirect_uri per RFC 7636.
+     */
+    async exchangeCode(
+        discovery: OidcDiscovery,
+        code: string,
+        pkceSession: PkceSession,
+    ): Promise<TokenResponse> {
+        const body = new URLSearchParams({
+            grant_type: 'authorization_code',
+            client_id: this.config.clientId,
+            code,
+            redirect_uri: this.config.redirectUri,
+            code_verifier: pkceSession.codeVerifier,
+        });
+
+        const response = await fetch(discovery.token_endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
+        });
+
+        if (!response.ok) {
+            const text = await response.text().catch(() => '');
+            throw new Error(`Token exchange failed: HTTP ${response.status}: ${text}`);
+        }
+
+        return response.json() as Promise<TokenResponse>;
+    }
+
+    /**
+     * Refreshes tokens using a stored refresh token.
+     * POSTs grant_type=refresh_token to the token endpoint.
+     */
+    async refreshTokens(discovery: OidcDiscovery, refreshToken: string): Promise<TokenResponse> {
+        const body = new URLSearchParams({
+            grant_type: 'refresh_token',
+            client_id: this.config.clientId,
+            refresh_token: refreshToken,
+        });
+
+        const response = await fetch(discovery.token_endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
+        });
+
+        if (!response.ok) {
+            const text = await response.text().catch(() => '');
+            throw new Error(`Token refresh failed: HTTP ${response.status}: ${text}`);
+        }
+
+        return response.json() as Promise<TokenResponse>;
+    }
+
+    /**
+     * Builds the RP-initiated logout URL.
+     * Uses end_session_endpoint if available (required for proper server-side session
+     * termination). Falls back to postLogoutRedirectUri if the provider does not
+     * advertise an end_session_endpoint.
+     */
+    buildLogoutUrl(discovery: OidcDiscovery, idToken: string | null): string {
+        if (!discovery.end_session_endpoint) {
+            return this.config.postLogoutRedirectUri;
+        }
+
+        const params = new URLSearchParams({
+            post_logout_redirect_uri: this.config.postLogoutRedirectUri,
+        });
+
+        if (idToken !== null) {
+            params.set('id_token_hint', idToken);
+        }
+
+        return `${discovery.end_session_endpoint}?${params.toString()}`;
+    }
+
+    /**
+     * Parses a JWT without signature verification.
+     * The server validates the signature; the client only needs claims for UI
+     * and expiry scheduling purposes.
+     */
+    parseToken(jwt: string): ParsedToken {
+        const parts = jwt.split('.');
+        if (parts.length !== 3) {
+            throw new Error('Invalid JWT format: expected 3 parts');
+        }
+
+        const payload = parts[1];
+        if (payload === undefined) {
+            throw new Error('Invalid JWT: missing payload');
+        }
+
+        // base64url → base64 → decode
+        const padded = payload.replace(/-/g, '+').replace(/_/g, '/');
+        const padding = (4 - (padded.length % 4)) % 4;
+        const base64 = padded + '='.repeat(padding);
+        const decoded = atob(base64);
+        const parsed = JSON.parse(decoded) as Record<string, unknown>;
+
+        if (typeof parsed['sub'] !== 'string') {
+            throw new Error('JWT missing required sub claim');
+        }
+        if (typeof parsed['exp'] !== 'number') {
+            throw new Error('JWT missing required exp claim');
+        }
+
+        return {
+            sub: parsed['sub'] as string,
+            exp: parsed['exp'] as number,
+            iat: typeof parsed['iat'] === 'number' ? parsed['iat'] as number : 0,
+            iss: typeof parsed['iss'] === 'string' ? parsed['iss'] as string : '',
+            aud: parsed['aud'] as string | string[] | undefined,
+            sid: typeof parsed['sid'] === 'string' ? parsed['sid'] as string : undefined,
+            preferred_username: typeof parsed['preferred_username'] === 'string'
+                ? parsed['preferred_username'] as string
+                : undefined,
+            email: typeof parsed['email'] === 'string' ? parsed['email'] as string : undefined,
+            roles: Array.isArray(parsed['roles'])
+                ? (parsed['roles'] as unknown[]).filter((r): r is string => typeof r === 'string')
+                : undefined,
+        };
+    }
+}
+
+/**
+ * Encodes a Uint8Array as base64url (RFC 4648 §5, no padding).
+ * Replaces '+' with '-', '/' with '_', and strips trailing '='.
+ */
+function base64urlEncode(data: Uint8Array): string {
+    // Build a binary string from the byte array for btoa()
+    let binary = '';
+    for (let i = 0; i < data.length; i++) {
+        binary += String.fromCharCode(data[i]!);
+    }
+    return btoa(binary)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+}

--- a/Implementation/clients/dispatcher-client/src/auth/SessionManager.ts
+++ b/Implementation/clients/dispatcher-client/src/auth/SessionManager.ts
@@ -1,0 +1,96 @@
+// Enforces idle session timeout and maximum session lifetime per NFR Security:
+// "Dispatcher Client and Admin Client must have idle session timeouts."
+// "All clients must have a maximum session lifetime, after which re-authentication is required."
+
+import type { SessionConfig } from '../config/AppConfig.ts';
+import { AuthState, SessionWarningEvent } from './AuthState.ts';
+
+/** How often to check session expiry (every 30 seconds). */
+const CHECK_INTERVAL_MS = 30_000;
+
+/** Warn the user this many seconds before a session limit is reached. */
+const WARNING_THRESHOLD_S = 300;
+
+export class SessionManager {
+    #lastActivity: number = Date.now();
+    #intervalId: ReturnType<typeof setInterval> | null = null;
+    #activityHandler: () => void;
+
+    constructor(
+        private readonly authState: AuthState,
+        private readonly config: SessionConfig,
+    ) {
+        this.#activityHandler = () => {
+            this.#lastActivity = Date.now();
+        };
+    }
+
+    /** Start activity tracking and session expiry checks. */
+    start(): void {
+        if (this.#intervalId !== null) return; // already running
+
+        this.#lastActivity = Date.now();
+
+        // Listen for any user activity to reset the idle clock
+        document.addEventListener('mousemove', this.#activityHandler, { passive: true });
+        document.addEventListener('keydown', this.#activityHandler, { passive: true });
+        document.addEventListener('click', this.#activityHandler, { passive: true });
+        document.addEventListener('touchstart', this.#activityHandler, { passive: true });
+
+        this.#intervalId = setInterval(() => this.#check(), CHECK_INTERVAL_MS);
+    }
+
+    /** Stop activity tracking and session expiry checks (called on logout or expiry). */
+    stop(): void {
+        if (this.#intervalId !== null) {
+            clearInterval(this.#intervalId);
+            this.#intervalId = null;
+        }
+        document.removeEventListener('mousemove', this.#activityHandler);
+        document.removeEventListener('keydown', this.#activityHandler);
+        document.removeEventListener('click', this.#activityHandler);
+        document.removeEventListener('touchstart', this.#activityHandler);
+    }
+
+    #check(): void {
+        const now = Date.now();
+
+        // --- Idle timeout check ---
+        const idleSecs = (now - this.#lastActivity) / 1000;
+        const idleRemaining = this.config.idleTimeoutSeconds - idleSecs;
+
+        if (idleRemaining <= 0) {
+            this.stop();
+            this.authState.forceLogout('idle-timeout');
+            return;
+        }
+
+        if (idleRemaining <= WARNING_THRESHOLD_S) {
+            this.authState.dispatchEvent(
+                new SessionWarningEvent('idle-timeout', Math.ceil(idleRemaining)),
+            );
+        }
+
+        // --- Max session lifetime check ---
+        const loginAtRaw = sessionStorage.getItem('idispatchx.login_at');
+        if (loginAtRaw !== null) {
+            const loginAt = parseInt(loginAtRaw, 10);
+            if (!isNaN(loginAt)) {
+                const sessionAgeSecs = (now - loginAt) / 1000;
+                const lifetimeRemaining = this.config.maxLifetimeSeconds - sessionAgeSecs;
+
+                if (lifetimeRemaining <= 0) {
+                    this.stop();
+                    this.authState.forceLogout('max-lifetime');
+                    return;
+                }
+
+                if (lifetimeRemaining <= WARNING_THRESHOLD_S) {
+                    this.authState.dispatchEvent(
+                        new SessionWarningEvent('max-lifetime', Math.ceil(lifetimeRemaining)),
+                    );
+                }
+            }
+        }
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/auth/types.ts
+++ b/Implementation/clients/dispatcher-client/src/auth/types.ts
@@ -1,0 +1,64 @@
+// Shared types for OIDC authentication in the Dispatcher Client.
+
+/** Raw response from the OIDC token endpoint. */
+export interface TokenResponse {
+    access_token: string;
+    token_type: string;
+    expires_in: number;
+    refresh_token?: string;
+    refresh_expires_in?: number;
+    id_token?: string;
+    scope?: string;
+}
+
+/**
+ * Parsed JWT claims relevant to iDispatchX.
+ * Roles are extracted from the top-level "roles" claim per the Security NFR
+ * (ADR-0001 requires standard claims only; backend TokenValidator uses "roles").
+ */
+export interface ParsedToken {
+    sub: string;
+    exp: number;
+    iat: number;
+    iss: string;
+    aud?: string | string[];
+    sid?: string;
+    preferred_username?: string;
+    email?: string;
+    roles?: string[];
+}
+
+/** Hydrated token set. The access token lives in memory only. */
+export interface TokenSet {
+    accessToken: string;
+    idToken: string | null;
+    refreshToken: string | null;
+    /** Expiry as Unix epoch milliseconds. */
+    expiresAt: number;
+    parsedAccess: ParsedToken;
+}
+
+/** Subset of the OIDC discovery document that the client uses. */
+export interface OidcDiscovery {
+    issuer: string;
+    authorization_endpoint: string;
+    token_endpoint: string;
+    end_session_endpoint?: string;
+    jwks_uri: string;
+}
+
+/** PKCE session state stored in sessionStorage during the redirect round-trip. */
+export interface PkceSession {
+    codeVerifier: string;
+    /** Random nonce; compared to the state param returned in the callback URL. */
+    state: string;
+    /** Timestamp when the PKCE session was started, to detect stale sessions. */
+    startedAt: number;
+}
+
+/** Auth state snapshot used for events and rendering decisions. */
+export type AuthStatus =
+    | { kind: 'unauthenticated' }
+    | { kind: 'authenticating' }
+    | { kind: 'authenticated'; tokenSet: TokenSet }
+    | { kind: 'expired'; reason: 'idle-timeout' | 'max-lifetime' | 'forced-logout' };

--- a/Implementation/clients/dispatcher-client/src/config/AppConfig.ts
+++ b/Implementation/clients/dispatcher-client/src/config/AppConfig.ts
@@ -1,0 +1,113 @@
+// Runtime configuration for the iDispatchX Dispatcher Client.
+// The config is loaded from /config.json at startup, allowing ops to replace
+// it per environment without rebuilding. Falls back to window.__APP_CONFIG__
+// for environments that inject config via the HTML template.
+
+export interface OidcConfig {
+    readonly issuer: string;
+    readonly clientId: string;
+    readonly redirectUri: string;
+    readonly scopes: string[];
+    readonly postLogoutRedirectUri: string;
+}
+
+export interface SessionConfig {
+    readonly idleTimeoutSeconds: number;
+    readonly maxLifetimeSeconds: number;
+}
+
+export interface AppConfig {
+    readonly oidc: OidcConfig;
+    readonly session: SessionConfig;
+}
+
+declare global {
+    interface Window {
+        __APP_CONFIG__?: AppConfig;
+    }
+}
+
+export async function loadAppConfig(): Promise<AppConfig> {
+    let raw: unknown;
+
+    // VITE_CONFIG_URL allows test environments to serve a different config file
+    // without modifying the default config.json (set via webServer.env in playwright.config.ts).
+    const configUrl = (import.meta.env['VITE_CONFIG_URL'] as string | undefined) ?? '/config.json';
+
+    try {
+        const response = await fetch(configUrl);
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        raw = await response.json();
+    } catch {
+        if (window.__APP_CONFIG__ !== undefined) {
+            raw = window.__APP_CONFIG__;
+        } else {
+            throw new Error(
+                'Failed to load /config.json and no window.__APP_CONFIG__ fallback is present. ' +
+                'Ensure config.json is served alongside the application.'
+            );
+        }
+    }
+
+    return validateConfig(raw);
+}
+
+function validateConfig(raw: unknown): AppConfig {
+    if (typeof raw !== 'object' || raw === null) {
+        throw new Error('AppConfig must be a JSON object');
+    }
+
+    const obj = raw as Record<string, unknown>;
+
+    if (typeof obj['oidc'] !== 'object' || obj['oidc'] === null) {
+        throw new Error('AppConfig.oidc is required');
+    }
+    const oidc = obj['oidc'] as Record<string, unknown>;
+
+    requireNonBlankString(oidc, 'oidc.issuer');
+    requireNonBlankString(oidc, 'oidc.clientId');
+    requireNonBlankString(oidc, 'oidc.redirectUri');
+    requireNonBlankString(oidc, 'oidc.postLogoutRedirectUri');
+
+    if (!Array.isArray(oidc['scopes']) || oidc['scopes'].length === 0) {
+        throw new Error('AppConfig.oidc.scopes must be a non-empty array');
+    }
+
+    if (typeof obj['session'] !== 'object' || obj['session'] === null) {
+        throw new Error('AppConfig.session is required');
+    }
+    const session = obj['session'] as Record<string, unknown>;
+
+    requirePositiveNumber(session, 'session.idleTimeoutSeconds');
+    requirePositiveNumber(session, 'session.maxLifetimeSeconds');
+
+    return {
+        oidc: {
+            issuer: oidc['issuer'] as string,
+            clientId: oidc['clientId'] as string,
+            redirectUri: oidc['redirectUri'] as string,
+            scopes: oidc['scopes'] as string[],
+            postLogoutRedirectUri: oidc['postLogoutRedirectUri'] as string,
+        },
+        session: {
+            idleTimeoutSeconds: session['idleTimeoutSeconds'] as number,
+            maxLifetimeSeconds: session['maxLifetimeSeconds'] as number,
+        },
+    };
+}
+
+function requireNonBlankString(obj: Record<string, unknown>, path: string): void {
+    const key = path.split('.').pop()!;
+    if (typeof obj[key] !== 'string' || (obj[key] as string).trim() === '') {
+        throw new Error(`AppConfig.${path} must be a non-blank string`);
+    }
+}
+
+function requirePositiveNumber(obj: Record<string, unknown>, path: string): void {
+    const key = path.split('.').pop()!;
+    if (typeof obj[key] !== 'number' || (obj[key] as number) <= 0) {
+        throw new Error(`AppConfig.${path} must be a positive number`);
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/http/HttpClient.ts
+++ b/Implementation/clients/dispatcher-client/src/http/HttpClient.ts
@@ -1,0 +1,104 @@
+// Base HTTP client for the Dispatcher Client.
+// Attaches Authorization: Bearer headers to every request and detects 401
+// responses so that forced session termination (back-channel logout or admin
+// revocation) can be handled gracefully.
+
+import type { AuthState } from '../auth/AuthState.ts';
+
+export class HttpError extends Error {
+    constructor(
+        readonly status: number,
+        readonly body: string,
+        readonly url: string,
+    ) {
+        super(`HTTP ${status} from ${url}: ${body}`);
+    }
+}
+
+export class UnauthorizedError extends Error {
+    constructor() {
+        super('Unauthorized — session has been revoked or token has expired');
+    }
+}
+
+export class HttpClient {
+    constructor(
+        private readonly authState: AuthState,
+        private readonly onUnauthorized: () => void,
+    ) {}
+
+    async get<T>(url: string, options?: RequestInit): Promise<T> {
+        return this.#request<T>(url, { ...options, method: 'GET' });
+    }
+
+    async post<T>(url: string, body: unknown, options?: RequestInit): Promise<T> {
+        return this.#request<T>(url, {
+            ...options,
+            method: 'POST',
+            headers: this.#mergeHeaders(options?.headers, { 'Content-Type': 'application/json' }),
+            body: JSON.stringify(body),
+        });
+    }
+
+    async put<T>(url: string, body: unknown, options?: RequestInit): Promise<T> {
+        return this.#request<T>(url, {
+            ...options,
+            method: 'PUT',
+            headers: this.#mergeHeaders(options?.headers, { 'Content-Type': 'application/json' }),
+            body: JSON.stringify(body),
+        });
+    }
+
+    async patch<T>(url: string, body: unknown, options?: RequestInit): Promise<T> {
+        return this.#request<T>(url, {
+            ...options,
+            method: 'PATCH',
+            headers: this.#mergeHeaders(options?.headers, { 'Content-Type': 'application/json' }),
+            body: JSON.stringify(body),
+        });
+    }
+
+    async delete(url: string, options?: RequestInit): Promise<void> {
+        await this.#request<void>(url, { ...options, method: 'DELETE' });
+    }
+
+    async #request<T>(url: string, init: RequestInit): Promise<T> {
+        const headers = new Headers(init.headers);
+
+        const token = this.authState.getAccessToken();
+        if (token !== null) {
+            headers.set('Authorization', `Bearer ${token}`);
+        }
+
+        const response = await fetch(url, { ...init, headers });
+
+        if (response.status === 401) {
+            this.onUnauthorized();
+            throw new UnauthorizedError();
+        }
+
+        if (!response.ok) {
+            const body = await response.text().catch(() => '');
+            throw new HttpError(response.status, body, url);
+        }
+
+        if (response.status === 204 || response.headers.get('Content-Length') === '0') {
+            return undefined as T;
+        }
+
+        return response.json() as Promise<T>;
+    }
+
+    #mergeHeaders(
+        existing: HeadersInit | undefined,
+        additions: Record<string, string>,
+    ): Headers {
+        const headers = new Headers(existing);
+        for (const [key, value] of Object.entries(additions)) {
+            if (!headers.has(key)) {
+                headers.set(key, value);
+            }
+        }
+        return headers;
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/index.html
+++ b/Implementation/clients/dispatcher-client/src/index.html
@@ -5,21 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="referrer" content="no-referrer">
     <title>iDispatchX Dispatcher</title>
-    <style>
-        *, *::before, *::after { box-sizing: border-box; }
-        html, body {
-            margin: 0;
-            padding: 0;
-            width: 100%;
-            height: 100%;
-            background: #1e1e1e;
-            overflow: hidden;
-        }
-        #app {
-            width: 100%;
-            height: 100%;
-        }
-    </style>
+    <link rel="stylesheet" href="/styles/tokens.css">
+    <link rel="stylesheet" href="/styles/base.css">
 </head>
 <body>
     <div id="app"></div>

--- a/Implementation/clients/dispatcher-client/src/index.html
+++ b/Implementation/clients/dispatcher-client/src/index.html
@@ -3,7 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="referrer" content="no-referrer">
     <title>iDispatchX Dispatcher</title>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        html, body {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            background: #1e1e1e;
+            overflow: hidden;
+        }
+        #app {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
 </head>
 <body>
     <div id="app"></div>

--- a/Implementation/clients/dispatcher-client/src/main.ts
+++ b/Implementation/clients/dispatcher-client/src/main.ts
@@ -1,2 +1,76 @@
-// iDispatchX Dispatcher Client
-// Entry point
+// iDispatchX Dispatcher Client — entry point
+//
+// Boot sequence:
+//   1. Register custom elements
+//   2. Mount AppShell immediately (shows loading screen)
+//   3. Load runtime config from /config.json
+//   4. Wire dependencies
+//   5. Initialize OIDC auth (may redirect browser to OIDC provider)
+
+import { loadAppConfig } from './config/AppConfig.ts';
+import { OidcClient } from './auth/OidcClient.ts';
+import { AuthState } from './auth/AuthState.ts';
+import { SessionManager } from './auth/SessionManager.ts';
+import { HttpClient } from './http/HttpClient.ts';
+import { AppShell } from './ui/AppShell.ts';
+import { LoginScreen } from './ui/LoginScreen.ts';
+
+// Register custom elements before any template or innerHTML usage
+customElements.define(LoginScreen.TAG, LoginScreen);
+customElements.define(AppShell.TAG, AppShell);
+
+async function boot(): Promise<void> {
+    const appEl = document.getElementById('app');
+    if (!appEl) {
+        throw new Error('Missing #app element in index.html');
+    }
+
+    // Load runtime configuration
+    const config = await loadAppConfig();
+
+    // Construct OIDC objects (pure construction, no network calls yet)
+    const oidcClient = new OidcClient(config.oidc);
+    const authState = new AuthState(oidcClient, config);
+    const sessionManager = new SessionManager(authState, config.session);
+
+    // The HttpClient is the entry point for all authenticated API calls.
+    // On 401, it signals that the server has revoked the session.
+    const httpClient = new HttpClient(authState, () => {
+        authState.forceLogout('forced-logout');
+    });
+
+    // Mount the AppShell AFTER initialize() so that connectedCallback fires
+    // with a fully wired authState — ensuring event listeners are registered.
+    const shell = document.createElement(AppShell.TAG) as AppShell;
+    shell.initialize(authState, sessionManager);
+    appEl.appendChild(shell);
+
+    // Expose authState for Playwright E2E tests in development mode
+    if (import.meta.env.DEV) {
+        (window as Window & { __authState?: AuthState; __httpClient?: HttpClient }).__authState = authState;
+        (window as Window & { __authState?: AuthState; __httpClient?: HttpClient }).__httpClient = httpClient;
+    }
+
+    // Start the OIDC boot sequence. This may redirect the browser.
+    await authState.initialize();
+}
+
+boot().catch((err: unknown) => {
+    console.error('[main] Fatal boot error:', err);
+
+    const appEl = document.getElementById('app');
+    if (appEl) {
+        appEl.innerHTML = `
+            <div style="
+                position:fixed;inset:0;background:#1e1e1e;color:#f48771;
+                display:grid;place-items:center;
+                font-family:'Segoe UI',system-ui,sans-serif;font-size:14px;
+            ">
+                <div style="text-align:center;max-width:400px;padding:32px">
+                    <strong>iDispatchX could not start.</strong><br><br>
+                    Failed to load configuration. Please contact your system administrator.<br><br>
+                    <code style="font-size:12px;color:#9d9d9d">${String(err)}</code>
+                </div>
+            </div>`;
+    }
+});

--- a/Implementation/clients/dispatcher-client/src/public/config.json
+++ b/Implementation/clients/dispatcher-client/src/public/config.json
@@ -1,0 +1,13 @@
+{
+  "oidc": {
+    "issuer": "http://localhost:8080/realms/idispatchx",
+    "clientId": "dispatcher-client",
+    "redirectUri": "http://localhost:5173/",
+    "scopes": ["openid", "profile"],
+    "postLogoutRedirectUri": "http://localhost:5173/"
+  },
+  "session": {
+    "idleTimeoutSeconds": 900,
+    "maxLifetimeSeconds": 28800
+  }
+}

--- a/Implementation/clients/dispatcher-client/src/public/config.test.json
+++ b/Implementation/clients/dispatcher-client/src/public/config.test.json
@@ -1,0 +1,13 @@
+{
+  "oidc": {
+    "issuer": "http://localhost:8180/realms/idispatchx",
+    "clientId": "dispatcher-client",
+    "redirectUri": "http://localhost:5173/",
+    "scopes": ["openid", "profile"],
+    "postLogoutRedirectUri": "http://localhost:5173/"
+  },
+  "session": {
+    "idleTimeoutSeconds": 900,
+    "maxLifetimeSeconds": 28800
+  }
+}

--- a/Implementation/clients/dispatcher-client/src/styles/base.css
+++ b/Implementation/clients/dispatcher-client/src/styles/base.css
@@ -1,0 +1,24 @@
+/*
+ * iDispatchX base styles — box model reset and full-viewport layout.
+ */
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--color-bg-base);
+    overflow: hidden;
+}
+
+#app {
+    width: 100%;
+    height: 100%;
+}

--- a/Implementation/clients/dispatcher-client/src/styles/tokens.css
+++ b/Implementation/clients/dispatcher-client/src/styles/tokens.css
@@ -1,0 +1,43 @@
+/*
+ * iDispatchX design tokens — CSS custom properties.
+ * Defined on :root so they cascade into shadow DOMs via inheritance.
+ */
+
+:root {
+    /* Background surfaces */
+    --color-bg-base:    #1e1e1e;
+    --color-bg-surface: #252526;
+    --color-bg-border:  #454545;
+
+    /* Text */
+    --color-text-primary:   #ffffff;
+    --color-text-secondary: #cccccc;
+    --color-text-muted:     #9d9d9d;
+
+    /* Accent (brand blue) */
+    --color-accent:        #0078d4;
+    --color-accent-hover:  #106ebe;
+    --color-accent-active: #005a9e;
+
+    /* Warning / session-expiry banner */
+    --color-warning-bg:   #664d00;
+    --color-warning-text: #ffd700;
+
+    /* Typography */
+    --font-family-ui: "Segoe UI", system-ui, -apple-system, sans-serif;
+    --font-size-sm:   12px;
+    --font-size-base: 14px;
+    --font-size-lg:   20px;
+
+    /* Spacing */
+    --space-xs:  4px;
+    --space-sm:  8px;
+    --space-md:  16px;
+    --space-lg:  24px;
+    --space-xl:  40px;
+    --space-2xl: 48px;
+
+    /* Border radius */
+    --radius-sm: 3px;
+    --radius-md: 6px;
+}

--- a/Implementation/clients/dispatcher-client/src/ui/AppShell.css
+++ b/Implementation/clients/dispatcher-client/src/ui/AppShell.css
@@ -1,0 +1,50 @@
+/*
+ * Styles for <idispatch-app-shell>.
+ * Rendered inside a shadow DOM; variables cascade in from :root via tokens.css.
+ */
+
+:host {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.app-content {
+    width: 100%;
+    height: 100%;
+}
+
+.session-warning {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: var(--color-warning-bg);
+    color: var(--color-warning-text);
+    font-family: var(--font-family-ui);
+    font-size: var(--font-size-sm);
+    padding: var(--space-sm) var(--space-md);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.warning-message {
+    flex: 1;
+}
+
+.dismiss-button {
+    background: none;
+    border: 1px solid var(--color-warning-text);
+    color: var(--color-warning-text);
+    border-radius: var(--radius-sm);
+    padding: 2px 10px;
+    font-size: var(--font-size-sm);
+    font-family: inherit;
+    cursor: pointer;
+}
+
+.dismiss-button:hover {
+    background: rgba(255, 215, 0, 0.15);
+}

--- a/Implementation/clients/dispatcher-client/src/ui/AppShell.css
+++ b/Implementation/clients/dispatcher-client/src/ui/AppShell.css
@@ -14,6 +14,37 @@
     height: 100%;
 }
 
+.app-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-sm);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--color-bg-surface);
+    border-bottom: 1px solid var(--color-bg-border);
+    font-family: var(--font-family-ui);
+    font-size: var(--font-size-sm);
+}
+
+.toolbar-username {
+    color: var(--color-text-secondary);
+}
+
+.toolbar-sign-out {
+    background: none;
+    border: 1px solid var(--color-bg-border);
+    color: var(--color-text-primary);
+    border-radius: var(--radius-sm);
+    padding: 2px 10px;
+    font-size: var(--font-size-sm);
+    font-family: inherit;
+    cursor: pointer;
+}
+
+.toolbar-sign-out:hover {
+    background: var(--color-bg-base);
+}
+
 .session-warning {
     position: fixed;
     top: 0;

--- a/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
@@ -2,58 +2,11 @@
 // Manages authentication state display, session warning banners,
 // and transitions between login and authenticated views.
 
+import STYLES from './AppShell.css?inline';
 import { AuthChangedEvent, AuthState, SessionWarningEvent } from '../auth/AuthState.ts';
 import type { AuthStatus } from '../auth/types.ts';
 import { LoginRequestedEvent, LoginScreen } from './LoginScreen.ts';
 import type { SessionManager } from '../auth/SessionManager.ts';
-
-const STYLES = `
-  :host {
-    display: block;
-    width: 100%;
-    height: 100%;
-  }
-
-  .app-content {
-    width: 100%;
-    height: 100%;
-  }
-
-  .warning-banner {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    background: #664d00;
-    color: #ffd700;
-    font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
-    font-size: 13px;
-    padding: 8px 16px;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .warning-banner span {
-    flex: 1;
-  }
-
-  .warning-dismiss {
-    background: none;
-    border: 1px solid #ffd700;
-    color: #ffd700;
-    border-radius: 3px;
-    padding: 2px 10px;
-    font-size: 12px;
-    font-family: inherit;
-    cursor: pointer;
-  }
-
-  .warning-dismiss:hover {
-    background: rgba(255, 215, 0, 0.15);
-  }
-`;
 
 /**
  * `<idispatch-app-shell>` Web Component.
@@ -190,21 +143,22 @@ export class AppShell extends HTMLElement {
         this.#dismissWarningBanner();
 
         const banner = document.createElement('div');
-        banner.className = 'warning-banner';
+        banner.className = 'session-warning';
         banner.setAttribute('role', 'alert');
 
         const minutesRemaining = Math.ceil(secondsRemaining / 60);
         const cause = reason === 'idle-timeout' ? 'inactivity' : 'reaching the maximum session duration';
-        const span = document.createElement('span');
-        span.textContent = `Your session will expire in approximately ${minutesRemaining} minute${minutesRemaining === 1 ? '' : 's'} due to ${cause}. Please save your work.`;
+        const messageEl = document.createElement('span');
+        messageEl.className = 'warning-message';
+        messageEl.textContent = `Your session will expire in approximately ${minutesRemaining} minute${minutesRemaining === 1 ? '' : 's'} due to ${cause}. Please save your work.`;
 
         const dismissBtn = document.createElement('button');
-        dismissBtn.className = 'warning-dismiss';
+        dismissBtn.className = 'dismiss-button';
         dismissBtn.textContent = 'Dismiss';
         dismissBtn.setAttribute('type', 'button');
         dismissBtn.addEventListener('click', () => this.#dismissWarningBanner());
 
-        banner.appendChild(span);
+        banner.appendChild(messageEl);
         banner.appendChild(dismissBtn);
         this.#shadow.appendChild(banner);
         this.#warningBanner = banner;

--- a/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
@@ -1,0 +1,219 @@
+// Root Web Component for the Dispatcher Client.
+// Manages authentication state display, session warning banners,
+// and transitions between login and authenticated views.
+
+import { AuthChangedEvent, AuthState, SessionWarningEvent } from '../auth/AuthState.ts';
+import type { AuthStatus } from '../auth/types.ts';
+import { LoginRequestedEvent, LoginScreen } from './LoginScreen.ts';
+import type { SessionManager } from '../auth/SessionManager.ts';
+
+const STYLES = `
+  :host {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .app-content {
+    width: 100%;
+    height: 100%;
+  }
+
+  .warning-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: #664d00;
+    color: #ffd700;
+    font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+    font-size: 13px;
+    padding: 8px 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .warning-banner span {
+    flex: 1;
+  }
+
+  .warning-dismiss {
+    background: none;
+    border: 1px solid #ffd700;
+    color: #ffd700;
+    border-radius: 3px;
+    padding: 2px 10px;
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .warning-dismiss:hover {
+    background: rgba(255, 215, 0, 0.15);
+  }
+`;
+
+/**
+ * `<idispatch-app-shell>` Web Component.
+ * Rendered by main.ts; dependencies are injected via initialize().
+ */
+export class AppShell extends HTMLElement {
+    static readonly TAG = 'idispatch-app-shell' as const;
+
+    #shadow: ShadowRoot;
+    #authState: AuthState | null = null;
+    #sessionManager: SessionManager | null = null;
+    #warningBanner: HTMLDivElement | null = null;
+
+    // Bound handler references for removeEventListener
+    #onAuthChanged: ((e: Event) => void) | null = null;
+    #onSessionWarning: ((e: Event) => void) | null = null;
+    #onLoginRequested: ((e: Event) => void) | null = null;
+
+    constructor() {
+        super();
+        this.#shadow = this.attachShadow({ mode: 'open' });
+    }
+
+    /**
+     * Injects dependencies after the element is constructed.
+     * Called by main.ts before the element is connected to the DOM.
+     */
+    initialize(authState: AuthState, sessionManager: SessionManager): void {
+        this.#authState = authState;
+        this.#sessionManager = sessionManager;
+    }
+
+    connectedCallback(): void {
+        const style = document.createElement('style');
+        style.textContent = STYLES;
+        this.#shadow.appendChild(style);
+
+        if (!this.#authState || !this.#sessionManager) {
+            // initialize() was not called — render an error state
+            const errEl = document.createElement('p');
+            errEl.textContent = 'Internal error: AppShell not initialized.';
+            this.#shadow.appendChild(errEl);
+            return;
+        }
+
+        // Show current status immediately
+        this.#renderStatus(this.#authState.getStatus());
+
+        // Subscribe to future state changes
+        this.#onAuthChanged = (e: Event) => {
+            const status = (e as AuthChangedEvent).detail;
+            this.#onStatusChanged(status);
+        };
+        this.#authState.addEventListener(AuthChangedEvent.TYPE, this.#onAuthChanged);
+
+        this.#onSessionWarning = (e: Event) => {
+            const { reason, secondsRemaining } = (e as SessionWarningEvent).detail;
+            this.#showWarningBanner(reason, secondsRemaining);
+        };
+        this.#authState.addEventListener(SessionWarningEvent.TYPE, this.#onSessionWarning);
+
+        // Handle "Sign in again" from the LoginScreen
+        this.#onLoginRequested = () => {
+            void this.#authState!.initialize();
+        };
+        this.#shadow.addEventListener(LoginRequestedEvent.TYPE, this.#onLoginRequested);
+    }
+
+    disconnectedCallback(): void {
+        if (this.#authState) {
+            if (this.#onAuthChanged) {
+                this.#authState.removeEventListener(AuthChangedEvent.TYPE, this.#onAuthChanged);
+            }
+            if (this.#onSessionWarning) {
+                this.#authState.removeEventListener(SessionWarningEvent.TYPE, this.#onSessionWarning);
+            }
+        }
+        if (this.#onLoginRequested) {
+            this.#shadow.removeEventListener(LoginRequestedEvent.TYPE, this.#onLoginRequested);
+        }
+    }
+
+    #onStatusChanged(status: AuthStatus): void {
+        if (status.kind === 'authenticated') {
+            this.#sessionManager!.start();
+        } else if (status.kind === 'expired' || status.kind === 'unauthenticated') {
+            this.#sessionManager!.stop();
+            this.#dismissWarningBanner();
+        }
+        this.#renderStatus(status);
+    }
+
+    #renderStatus(status: AuthStatus): void {
+        // Remove any existing login screen
+        const existingLogin = this.#shadow.querySelector(LoginScreen.TAG);
+        if (existingLogin) {
+            existingLogin.remove();
+        }
+
+        // Remove any existing app content placeholder
+        const existingContent = this.#shadow.querySelector('.app-content');
+        if (existingContent) {
+            existingContent.remove();
+        }
+
+        switch (status.kind) {
+            case 'unauthenticated':
+            case 'authenticating': {
+                const screen = document.createElement(LoginScreen.TAG) as LoginScreen;
+                screen.setAttribute('status', 'loading');
+                this.#shadow.appendChild(screen);
+                break;
+            }
+
+            case 'authenticated': {
+                const content = document.createElement('div');
+                content.className = 'app-content';
+                content.setAttribute('data-username', status.tokenSet.parsedAccess.preferred_username ?? status.tokenSet.parsedAccess.sub);
+                // Placeholder: full dispatcher UI will be built here in future iterations
+                this.#shadow.appendChild(content);
+                break;
+            }
+
+            case 'expired': {
+                const screen = document.createElement(LoginScreen.TAG) as LoginScreen;
+                screen.setAttribute('status', status.reason);
+                this.#shadow.appendChild(screen);
+                break;
+            }
+        }
+    }
+
+    #showWarningBanner(reason: 'idle-timeout' | 'max-lifetime', secondsRemaining: number): void {
+        this.#dismissWarningBanner();
+
+        const banner = document.createElement('div');
+        banner.className = 'warning-banner';
+        banner.setAttribute('role', 'alert');
+
+        const minutesRemaining = Math.ceil(secondsRemaining / 60);
+        const cause = reason === 'idle-timeout' ? 'inactivity' : 'reaching the maximum session duration';
+        const span = document.createElement('span');
+        span.textContent = `Your session will expire in approximately ${minutesRemaining} minute${minutesRemaining === 1 ? '' : 's'} due to ${cause}. Please save your work.`;
+
+        const dismissBtn = document.createElement('button');
+        dismissBtn.className = 'warning-dismiss';
+        dismissBtn.textContent = 'Dismiss';
+        dismissBtn.setAttribute('type', 'button');
+        dismissBtn.addEventListener('click', () => this.#dismissWarningBanner());
+
+        banner.appendChild(span);
+        banner.appendChild(dismissBtn);
+        this.#shadow.appendChild(banner);
+        this.#warningBanner = banner;
+    }
+
+    #dismissWarningBanner(): void {
+        if (this.#warningBanner) {
+            this.#warningBanner.remove();
+            this.#warningBanner = null;
+        }
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
@@ -125,6 +125,24 @@ export class AppShell extends HTMLElement {
                 const content = document.createElement('div');
                 content.className = 'app-content';
                 content.setAttribute('data-username', status.tokenSet.parsedAccess.preferred_username ?? status.tokenSet.parsedAccess.sub);
+
+                const toolbar = document.createElement('div');
+                toolbar.className = 'app-toolbar';
+
+                const username = document.createElement('span');
+                username.className = 'toolbar-username';
+                username.textContent = status.tokenSet.parsedAccess.preferred_username ?? status.tokenSet.parsedAccess.sub;
+
+                const signOutBtn = document.createElement('button');
+                signOutBtn.className = 'toolbar-sign-out';
+                signOutBtn.setAttribute('type', 'button');
+                signOutBtn.textContent = 'Sign out';
+                signOutBtn.addEventListener('click', () => { void this.#authState!.logout(); });
+
+                toolbar.appendChild(username);
+                toolbar.appendChild(signOutBtn);
+                content.appendChild(toolbar);
+
                 // Placeholder: full dispatcher UI will be built here in future iterations
                 this.#shadow.appendChild(content);
                 break;

--- a/Implementation/clients/dispatcher-client/src/ui/LoginScreen.css
+++ b/Implementation/clients/dispatcher-client/src/ui/LoginScreen.css
@@ -1,0 +1,95 @@
+/*
+ * Styles for <idispatch-login-screen>.
+ * Rendered inside a shadow DOM; variables cascade in from :root via tokens.css.
+ */
+
+:host {
+    display: block;
+}
+
+.login-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: var(--color-bg-base);
+    display: grid;
+    place-items: center;
+    font-family: var(--font-family-ui);
+    color: var(--color-text-secondary);
+}
+
+.login-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-md);
+    padding: var(--space-xl) var(--space-2xl);
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-bg-border);
+    border-radius: var(--radius-md);
+    min-width: 320px;
+    text-align: center;
+}
+
+.brand-logo {
+    width: 48px;
+    height: 48px;
+    background: var(--color-accent);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    letter-spacing: -0.5px;
+}
+
+h1 {
+    margin: 0;
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    color: var(--color-text-primary);
+}
+
+.status-message {
+    margin: 0;
+    font-size: var(--font-size-base);
+    color: var(--color-text-muted);
+    max-width: 260px;
+    line-height: 1.5;
+}
+
+.loading-indicator {
+    width: 24px;
+    height: 24px;
+    border: 2px solid var(--color-bg-border);
+    border-top-color: var(--color-accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.sign-in-button {
+    margin-top: var(--space-sm);
+    padding: var(--space-sm) var(--space-lg);
+    background: var(--color-accent);
+    color: var(--color-text-primary);
+    border: none;
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-base);
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.sign-in-button:hover {
+    background: var(--color-accent-hover);
+}
+
+.sign-in-button:active {
+    background: var(--color-accent-active);
+}

--- a/Implementation/clients/dispatcher-client/src/ui/LoginScreen.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/LoginScreen.ts
@@ -1,98 +1,7 @@
 // Login / session-expired screen Web Component.
 // Displayed while the OIDC flow is in progress or after a session ends.
 
-const STYLES = `
-  :host {
-    display: block;
-  }
-
-  .overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 9999;
-    background: #1e1e1e;
-    display: grid;
-    place-items: center;
-    font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
-    color: #cccccc;
-  }
-
-  .card {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 16px;
-    padding: 40px 48px;
-    background: #252526;
-    border: 1px solid #454545;
-    border-radius: 6px;
-    min-width: 320px;
-    text-align: center;
-  }
-
-  .logo {
-    width: 48px;
-    height: 48px;
-    background: #0078d4;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 18px;
-    font-weight: 700;
-    color: #ffffff;
-    letter-spacing: -0.5px;
-  }
-
-  h1 {
-    margin: 0;
-    font-size: 20px;
-    font-weight: 600;
-    color: #ffffff;
-  }
-
-  .message {
-    margin: 0;
-    font-size: 14px;
-    color: #9d9d9d;
-    max-width: 260px;
-    line-height: 1.5;
-  }
-
-  .spinner {
-    width: 24px;
-    height: 24px;
-    border: 2px solid #454545;
-    border-top-color: #0078d4;
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
-  }
-
-  @keyframes spin {
-    to { transform: rotate(360deg); }
-  }
-
-  .btn {
-    margin-top: 8px;
-    padding: 8px 24px;
-    background: #0078d4;
-    color: #ffffff;
-    border: none;
-    border-radius: 3px;
-    font-size: 14px;
-    font-family: inherit;
-    cursor: pointer;
-    transition: background 0.15s;
-  }
-
-  .btn:hover {
-    background: #106ebe;
-  }
-
-  .btn:active {
-    background: #005a9e;
-  }
-`;
+import STYLES from './LoginScreen.css?inline';
 
 type LoginScreenStatus = 'loading' | 'session-expired' | 'idle-timeout' | 'max-lifetime' | 'forced-logout';
 
@@ -126,8 +35,8 @@ export class LoginScreen extends HTMLElement {
 
     #shadow: ShadowRoot;
     #messageEl: HTMLParagraphElement | null = null;
-    #spinnerEl: HTMLDivElement | null = null;
-    #btnEl: HTMLButtonElement | null = null;
+    #loadingIndicatorEl: HTMLDivElement | null = null;
+    #signInButtonEl: HTMLButtonElement | null = null;
 
     constructor() {
         super();
@@ -153,15 +62,15 @@ export class LoginScreen extends HTMLElement {
         style.textContent = STYLES;
 
         const overlay = document.createElement('div');
-        overlay.className = 'overlay';
+        overlay.className = 'login-overlay';
         overlay.setAttribute('role', 'status');
         overlay.setAttribute('aria-live', 'polite');
 
         const card = document.createElement('div');
-        card.className = 'card';
+        card.className = 'login-card';
 
         const logo = document.createElement('div');
-        logo.className = 'logo';
+        logo.className = 'brand-logo';
         logo.textContent = 'iD';
         logo.setAttribute('aria-hidden', 'true');
 
@@ -169,20 +78,20 @@ export class LoginScreen extends HTMLElement {
         title.textContent = 'iDispatchX';
 
         this.#messageEl = document.createElement('p');
-        this.#messageEl.className = 'message';
+        this.#messageEl.className = 'status-message';
 
-        this.#spinnerEl = document.createElement('div');
-        this.#spinnerEl.className = 'spinner';
-        this.#spinnerEl.setAttribute('aria-hidden', 'true');
+        this.#loadingIndicatorEl = document.createElement('div');
+        this.#loadingIndicatorEl.className = 'loading-indicator';
+        this.#loadingIndicatorEl.setAttribute('aria-hidden', 'true');
 
-        this.#btnEl = document.createElement('button');
-        this.#btnEl.className = 'btn';
-        this.#btnEl.textContent = 'Sign in again';
-        this.#btnEl.addEventListener('click', () => {
+        this.#signInButtonEl = document.createElement('button');
+        this.#signInButtonEl.className = 'sign-in-button';
+        this.#signInButtonEl.textContent = 'Sign in again';
+        this.#signInButtonEl.addEventListener('click', () => {
             this.dispatchEvent(new LoginRequestedEvent());
         });
 
-        card.append(logo, title, this.#messageEl, this.#spinnerEl, this.#btnEl);
+        card.append(logo, title, this.#messageEl, this.#loadingIndicatorEl, this.#signInButtonEl);
         overlay.appendChild(card);
         this.#shadow.append(style, overlay);
 
@@ -190,13 +99,13 @@ export class LoginScreen extends HTMLElement {
     }
 
     #updateContent(): void {
-        if (!this.#messageEl || !this.#spinnerEl || !this.#btnEl) return;
+        if (!this.#messageEl || !this.#loadingIndicatorEl || !this.#signInButtonEl) return;
 
         const status = (this.getAttribute('status') ?? 'loading') as LoginScreenStatus;
         const isLoading = status === 'loading';
 
         this.#messageEl.textContent = STATUS_MESSAGES[status] ?? STATUS_MESSAGES['loading'];
-        this.#spinnerEl.style.display = isLoading ? 'block' : 'none';
-        this.#btnEl.style.display = isLoading ? 'none' : 'inline-block';
+        this.#loadingIndicatorEl.style.display = isLoading ? 'block' : 'none';
+        this.#signInButtonEl.style.display = isLoading ? 'none' : 'inline-block';
     }
 }

--- a/Implementation/clients/dispatcher-client/src/ui/LoginScreen.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/LoginScreen.ts
@@ -1,0 +1,199 @@
+// Login / session-expired screen Web Component.
+// Displayed while the OIDC flow is in progress or after a session ends.
+
+const STYLES = `
+  :host {
+    display: block;
+  }
+
+  .overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: #1e1e1e;
+    display: grid;
+    place-items: center;
+    font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+    color: #cccccc;
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    padding: 40px 48px;
+    background: #252526;
+    border: 1px solid #454545;
+    border-radius: 6px;
+    min-width: 320px;
+    text-align: center;
+  }
+
+  .logo {
+    width: 48px;
+    height: 48px;
+    background: #0078d4;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    font-weight: 700;
+    color: #ffffff;
+    letter-spacing: -0.5px;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 600;
+    color: #ffffff;
+  }
+
+  .message {
+    margin: 0;
+    font-size: 14px;
+    color: #9d9d9d;
+    max-width: 260px;
+    line-height: 1.5;
+  }
+
+  .spinner {
+    width: 24px;
+    height: 24px;
+    border: 2px solid #454545;
+    border-top-color: #0078d4;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+
+  .btn {
+    margin-top: 8px;
+    padding: 8px 24px;
+    background: #0078d4;
+    color: #ffffff;
+    border: none;
+    border-radius: 3px;
+    font-size: 14px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .btn:hover {
+    background: #106ebe;
+  }
+
+  .btn:active {
+    background: #005a9e;
+  }
+`;
+
+type LoginScreenStatus = 'loading' | 'session-expired' | 'idle-timeout' | 'max-lifetime';
+
+const STATUS_MESSAGES: Record<LoginScreenStatus, string> = {
+    'loading': 'Signing in…',
+    'session-expired': 'You have been signed out.',
+    'idle-timeout': 'You were signed out due to inactivity.',
+    'max-lifetime': 'Your session has reached its maximum duration.',
+};
+
+/** Event dispatched when the user clicks "Sign in again". Bubbles through the DOM. */
+export class LoginRequestedEvent extends CustomEvent<void> {
+    static readonly TYPE = 'login-requested' as const;
+
+    constructor() {
+        super(LoginRequestedEvent.TYPE, { bubbles: true, composed: true });
+    }
+}
+
+/**
+ * `<idispatch-login-screen>` Web Component.
+ *
+ * Attributes:
+ *   status — one of: "loading" (default), "session-expired", "idle-timeout", "max-lifetime"
+ */
+export class LoginScreen extends HTMLElement {
+    static readonly TAG = 'idispatch-login-screen' as const;
+
+    #shadow: ShadowRoot;
+    #messageEl: HTMLParagraphElement | null = null;
+    #spinnerEl: HTMLDivElement | null = null;
+    #btnEl: HTMLButtonElement | null = null;
+
+    constructor() {
+        super();
+        this.#shadow = this.attachShadow({ mode: 'open' });
+    }
+
+    static get observedAttributes(): string[] {
+        return ['status'];
+    }
+
+    connectedCallback(): void {
+        this.#render();
+    }
+
+    attributeChangedCallback(_name: string, _old: string | null, _value: string | null): void {
+        if (this.isConnected) {
+            this.#updateContent();
+        }
+    }
+
+    #render(): void {
+        const style = document.createElement('style');
+        style.textContent = STYLES;
+
+        const overlay = document.createElement('div');
+        overlay.className = 'overlay';
+        overlay.setAttribute('role', 'status');
+        overlay.setAttribute('aria-live', 'polite');
+
+        const card = document.createElement('div');
+        card.className = 'card';
+
+        const logo = document.createElement('div');
+        logo.className = 'logo';
+        logo.textContent = 'iD';
+        logo.setAttribute('aria-hidden', 'true');
+
+        const title = document.createElement('h1');
+        title.textContent = 'iDispatchX';
+
+        this.#messageEl = document.createElement('p');
+        this.#messageEl.className = 'message';
+
+        this.#spinnerEl = document.createElement('div');
+        this.#spinnerEl.className = 'spinner';
+        this.#spinnerEl.setAttribute('aria-hidden', 'true');
+
+        this.#btnEl = document.createElement('button');
+        this.#btnEl.className = 'btn';
+        this.#btnEl.textContent = 'Sign in again';
+        this.#btnEl.addEventListener('click', () => {
+            this.dispatchEvent(new LoginRequestedEvent());
+        });
+
+        card.append(logo, title, this.#messageEl, this.#spinnerEl, this.#btnEl);
+        overlay.appendChild(card);
+        this.#shadow.append(style, overlay);
+
+        this.#updateContent();
+    }
+
+    #updateContent(): void {
+        if (!this.#messageEl || !this.#spinnerEl || !this.#btnEl) return;
+
+        const status = (this.getAttribute('status') ?? 'loading') as LoginScreenStatus;
+        const isLoading = status === 'loading';
+
+        this.#messageEl.textContent = STATUS_MESSAGES[status] ?? STATUS_MESSAGES['loading'];
+        this.#spinnerEl.style.display = isLoading ? 'block' : 'none';
+        this.#btnEl.style.display = isLoading ? 'none' : 'inline-block';
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/ui/LoginScreen.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/LoginScreen.ts
@@ -94,13 +94,16 @@ const STYLES = `
   }
 `;
 
-type LoginScreenStatus = 'loading' | 'session-expired' | 'idle-timeout' | 'max-lifetime';
+type LoginScreenStatus = 'loading' | 'session-expired' | 'idle-timeout' | 'max-lifetime' | 'forced-logout';
 
 const STATUS_MESSAGES: Record<LoginScreenStatus, string> = {
     'loading': 'Signing in…',
     'session-expired': 'You have been signed out.',
     'idle-timeout': 'You were signed out due to inactivity.',
     'max-lifetime': 'Your session has reached its maximum duration.',
+    // Set by AppShell when the server revokes the session (back-channel logout
+    // or admin termination) or when OIDC discovery fails.
+    'forced-logout': 'You have been signed out.',
 };
 
 /** Event dispatched when the user clicks "Sign in again". Bubbles through the DOM. */

--- a/Implementation/clients/dispatcher-client/src/vite-env.d.ts
+++ b/Implementation/clients/dispatcher-client/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

- Implements OIDC Authorization Code Flow with PKCE for the Dispatcher Client SPA, satisfying NFR Security requirements for browser-based public clients (no client secret)
- Access token held in memory only; refresh token in `sessionStorage`; PKCE state nonce validated on every callback (CSRF protection)
- Idle session timeout and maximum session lifetime enforced via `SessionManager` (document activity listeners + `setInterval`); session-warning emitted 5 min before limit
- `HttpClient` wrapper converts HTTP 401 responses to forced session termination (handles back-channel logout / admin revocation from CAD Server)
- Vanilla Web Components (`AppShell`, `LoginScreen`) with Shadow DOM; loading/expired/idle/max-lifetime screens; "Sign in again" restarts OIDC flow via SSO

## Architecture

| File | Responsibility |
|------|---------------|
| `src/config/AppConfig.ts` | Loads `/config.json` at runtime; `VITE_CONFIG_URL` override for tests |
| `src/auth/types.ts` | Shared OIDC types (`TokenSet`, `ParsedToken`, `AuthStatus`, `PkceSession`) |
| `src/auth/OidcClient.ts` | Stateless PKCE mechanics using Web Crypto API |
| `src/auth/AuthState.ts` | Auth state machine; emits `AuthChangedEvent` on transitions |
| `src/auth/SessionManager.ts` | Idle timeout + max session lifetime enforcement |
| `src/http/HttpClient.ts` | Authenticated fetch wrapper with 401 detection |
| `src/ui/LoginScreen.ts` | `<idispatch-login-screen>` — loading/expired screens |
| `src/ui/AppShell.ts` | `<idispatch-app-shell>` — root component, wires everything |

## Test plan

- [x] `npm run build` passes TypeScript strict checks with zero errors
- [x] `npm test` runs 9 Playwright E2E tests against a real Keycloak 26.0.0 Docker container — all pass
- [ ] Tests cover: unauthenticated redirect, login success, wrong password, logout (RP-initiated), forced session termination (simulated 401), idle timeout, PKCE state mismatch (CSRF protection), SSO re-authentication after forced logout

## Automated testing setup

Playwright starts Keycloak automatically via `e2e/globalSetup.ts` (`docker run quay.io/keycloak/keycloak:26.0.0 start-dev --import-realm`). The realm config is in `docker/keycloak-realm.json`. Run with:

```sh
cd Implementation/clients/dispatcher-client
npx playwright install chromium
npx playwright install-deps chromium
npm test
```

## Manual testing setup

The Playwright tests use a Keycloak container on port **8180** with a pre-imported test realm. To reproduce that environment manually:

**1. Start Keycloak** (same image and realm as the automated tests):

```sh
cd Implementation/clients/dispatcher-client
docker run --detach \
  --name idispatchx-keycloak-test \
  -p 8180:8080 \
  -e KEYCLOAK_ADMIN=admin \
  -e KEYCLOAK_ADMIN_PASSWORD=admin \
  -e KC_HEALTH_ENABLED=true \
  -v "$(pwd)/docker/keycloak-realm.json:/opt/keycloak/data/import/realm.json" \
  quay.io/keycloak/keycloak:26.0.0 \
  start-dev --import-realm
```

Wait until the realm is ready (takes ~30 s) — poll until this returns HTTP 200:

```sh
curl -s -o /dev/null -w "%{http_code}" \
  http://localhost:8180/realms/idispatchx/.well-known/openid-configuration
```

**2. Start the dev server** pointing at the test Keycloak (port 8180):

```sh
cd Implementation/clients/dispatcher-client
VITE_CONFIG_URL=/config.test.json npm run dev
```

**3. Open the app** at http://localhost:5173

**Test credentials** (defined in `docker/keycloak-realm.json`):

| Username | Password |
|---|---|
| `test-dispatcher` | `Test1234!` |

**Scenarios to verify manually:**

- **Login**: the app redirects to Keycloak; after signing in with the credentials above it redirects back and shows the authenticated shell
- **Logout**: clicking Sign Out triggers RP-initiated logout; Keycloak clears the SSO session and redirects back to the login screen
- **Wrong password**: Keycloak shows an error; the app is unaffected on return to the login screen
- **SSO re-login**: after logout, clicking "Sign in again" resumes the OIDC flow without re-entering credentials if the Keycloak SSO session is still active (open a second tab first to keep the session alive)

**4. Stop Keycloak** when done:

```sh
docker stop idispatchx-keycloak-test && docker rm idispatchx-keycloak-test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)