### PR TITLE
Add Launcher Page and Primary/Secondary Windows to Dispatcher Client

### DIFF
--- a/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/auth.spec.ts
@@ -30,15 +30,15 @@ async function loginViaKeycloak(page: Page, username = TEST_USER, password = TES
 }
 
 /**
- * Waits for the app to be in an authenticated state.
- * Checks the AppShell's shadow DOM for the .app-content placeholder via page.waitForFunction,
+ * Waits for the app to be in an authenticated state (launcher page rendered).
+ * Checks the AppShell's shadow DOM via page.waitForFunction,
  * which is the most reliable way to cross shadow DOM boundaries.
  */
 async function expectAuthenticated(page: Page): Promise<void> {
     await page.waitForURL(APP_URL, { timeout: 10_000 });
     await page.waitForFunction(() => {
         const shell = document.querySelector('idispatch-app-shell');
-        return !!shell?.shadowRoot?.querySelector('.app-content');
+        return !!shell?.shadowRoot?.querySelector('idispatch-launcher-page');
     }, { timeout: 8_000 });
 }
 
@@ -339,7 +339,7 @@ test.describe('Authentication', () => {
         });
         await page.waitForFunction(() => {
             const shell = document.querySelector('idispatch-app-shell');
-            return !!shell?.shadowRoot?.querySelector('.app-content');
+            return !!shell?.shadowRoot?.querySelector('idispatch-launcher-page');
         }, { timeout: 5_000 });
 
         // The original refresh token must still be present — it was not rotated.

--- a/Implementation/clients/dispatcher-client/e2e/dispatcher-windows.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/dispatcher-windows.spec.ts
@@ -1,0 +1,246 @@
+// E2E tests for the primary and secondary dispatcher window structure.
+// Tests open windows via the launcher, then assert header and footer content
+// in the new page context.
+
+import { expect, test } from '@playwright/test';
+import type { Page, BrowserContext } from '@playwright/test';
+
+const APP_URL = 'http://localhost:5173/';
+const KEYCLOAK_ORIGIN = 'http://localhost:8180';
+
+const TEST_USER = 'test-dispatcher';
+const TEST_PASSWORD = 'Test1234!';
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+async function loginViaKeycloak(page: Page): Promise<void> {
+    await page.goto(APP_URL);
+    await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 10_000 });
+    await page.fill('input[name="username"]', TEST_USER);
+    await page.fill('input[name="password"]', TEST_PASSWORD);
+    await page.click('input[type="submit"], button[type="submit"]');
+}
+
+async function expectLauncherPage(page: Page): Promise<void> {
+    await page.waitForURL(APP_URL, { timeout: 10_000 });
+    await page.waitForFunction(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        return !!shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+    }, { timeout: 8_000 });
+}
+
+/** Opens a dispatcher window via the launcher and waits until it is authenticated. */
+async function openDispatcherWindow(
+    launcherPage: Page,
+    context: BrowserContext,
+    type: 'primary' | 'secondary',
+): Promise<Page> {
+    const btnClass = type === 'primary' ? 'open-primary-btn' : 'open-secondary-btn';
+    const windowTag = type === 'primary' ? 'idispatch-primary-window' : 'idispatch-secondary-window';
+
+    const [newPage] = await Promise.all([
+        context.waitForEvent('page', { timeout: 10_000 }),
+        launcherPage.evaluate((cls: string) => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+            const btn = launcher?.shadowRoot?.querySelector(`.${cls}`) as HTMLElement | null;
+            btn?.click();
+        }, btnClass),
+    ]);
+
+    // Wait for the dispatcher window to fully render (auth + component mount)
+    await newPage.waitForFunction((tag: string) => {
+        const shell = document.querySelector('idispatch-app-shell');
+        return !!shell?.shadowRoot?.querySelector(tag);
+    }, windowTag, { timeout: 20_000 });
+
+    return newPage;
+}
+
+/** Reads text from an element inside the window's deeply nested shadow DOM. */
+async function getWindowShadowText(
+    dispatcherPage: Page,
+    windowTag: string,
+    innerTag: string,
+    selector: string,
+): Promise<string | null> {
+    return dispatcherPage.evaluate(
+        ([wTag, iTag, sel]: string[]) => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const win = shell?.shadowRoot?.querySelector(wTag);
+            const inner = win?.shadowRoot?.querySelector(iTag);
+            return inner?.shadowRoot?.querySelector(sel)?.textContent?.trim() ?? null;
+        },
+        [windowTag, innerTag, selector],
+    );
+}
+
+// -------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------
+
+test.describe('Primary Window', () => {
+
+    test('header shows the iD logo', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const primaryPage = await openDispatcherWindow(page, context, 'primary');
+
+        const logoText = await getWindowShadowText(
+            primaryPage, 'idispatch-primary-window', 'idispatch-window-header', '.brand-logo',
+        );
+        expect(logoText).toBe('iD');
+
+        await primaryPage.close();
+    });
+
+    test('header clock shows date/time digits', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const primaryPage = await openDispatcherWindow(page, context, 'primary');
+
+        const clockText = await getWindowShadowText(
+            primaryPage, 'idispatch-primary-window', 'idispatch-window-header', '.header-clock',
+        );
+        expect(clockText).toBeTruthy();
+        // Should contain digits (date/time)
+        expect(clockText).toMatch(/\d/);
+
+        await primaryPage.close();
+    });
+
+    test('header clock updates every second', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const primaryPage = await openDispatcherWindow(page, context, 'primary');
+
+        const getClockText = (): Promise<string | null> =>
+            getWindowShadowText(primaryPage, 'idispatch-primary-window', 'idispatch-window-header', '.header-clock');
+
+        const before = await getClockText();
+        await primaryPage.waitForTimeout(1500);
+        const after = await getClockText();
+
+        expect(before).not.toBeNull();
+        expect(after).not.toBeNull();
+        expect(after).not.toBe(before);
+
+        await primaryPage.close();
+    });
+
+    test('header contains New Call and New Incident buttons', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const primaryPage = await openDispatcherWindow(page, context, 'primary');
+
+        const buttonTexts = await primaryPage.evaluate(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const win = shell?.shadowRoot?.querySelector('idispatch-primary-window');
+            const header = win?.shadowRoot?.querySelector('idispatch-window-header');
+            return Array.from(header?.shadowRoot?.querySelectorAll('button') ?? [])
+                .map(b => b.textContent?.trim());
+        });
+
+        expect(buttonTexts).toContain('New Call');
+        expect(buttonTexts).toContain('New Incident');
+
+        await primaryPage.close();
+    });
+
+    test('footer shows current username', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const primaryPage = await openDispatcherWindow(page, context, 'primary');
+
+        const footerUsername = await getWindowShadowText(
+            primaryPage, 'idispatch-primary-window', 'idispatch-window-footer', '.footer-left',
+        );
+        expect(footerUsername).toBe(TEST_USER);
+
+        await primaryPage.close();
+    });
+
+    test('footer shows Normal mode indicator', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const primaryPage = await openDispatcherWindow(page, context, 'primary');
+
+        const modeText = await getWindowShadowText(
+            primaryPage, 'idispatch-primary-window', 'idispatch-window-footer', '.footer-right',
+        );
+        expect(modeText).toBe('Normal');
+
+        await primaryPage.close();
+    });
+
+});
+
+test.describe('Secondary Window', () => {
+
+    test('header shows the iD logo and clock', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const secondaryPage = await openDispatcherWindow(page, context, 'secondary');
+
+        const logoText = await getWindowShadowText(
+            secondaryPage, 'idispatch-secondary-window', 'idispatch-window-header', '.brand-logo',
+        );
+        expect(logoText).toBe('iD');
+
+        const clockText = await getWindowShadowText(
+            secondaryPage, 'idispatch-secondary-window', 'idispatch-window-header', '.header-clock',
+        );
+        expect(clockText).toMatch(/\d/);
+
+        await secondaryPage.close();
+    });
+
+    test('header does NOT contain New Call or New Incident buttons', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const secondaryPage = await openDispatcherWindow(page, context, 'secondary');
+
+        const buttonTexts = await secondaryPage.evaluate(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const win = shell?.shadowRoot?.querySelector('idispatch-secondary-window');
+            const header = win?.shadowRoot?.querySelector('idispatch-window-header');
+            return Array.from(header?.shadowRoot?.querySelectorAll('button') ?? [])
+                .map(b => b.textContent?.trim());
+        });
+
+        expect(buttonTexts).not.toContain('New Call');
+        expect(buttonTexts).not.toContain('New Incident');
+
+        await secondaryPage.close();
+    });
+
+    test('footer shows current username and Normal mode', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const secondaryPage = await openDispatcherWindow(page, context, 'secondary');
+
+        const footerUsername = await getWindowShadowText(
+            secondaryPage, 'idispatch-secondary-window', 'idispatch-window-footer', '.footer-left',
+        );
+        expect(footerUsername).toBe(TEST_USER);
+
+        const modeText = await getWindowShadowText(
+            secondaryPage, 'idispatch-secondary-window', 'idispatch-window-footer', '.footer-right',
+        );
+        expect(modeText).toBe('Normal');
+
+        await secondaryPage.close();
+    });
+
+});

--- a/Implementation/clients/dispatcher-client/e2e/dispatcher-windows.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/dispatcher-windows.spec.ts
@@ -143,8 +143,9 @@ test.describe('Primary Window', () => {
             const shell = document.querySelector('idispatch-app-shell');
             const win = shell?.shadowRoot?.querySelector('idispatch-primary-window');
             const header = win?.shadowRoot?.querySelector('idispatch-window-header');
-            return Array.from(header?.shadowRoot?.querySelectorAll('button') ?? [])
-                .map(b => b.textContent?.trim());
+            // Buttons are distributed into the named slot — use assignedElements() to inspect them
+            const actionsSlot = header?.shadowRoot?.querySelector('slot[name="actions"]') as HTMLSlotElement | null;
+            return (actionsSlot?.assignedElements() ?? []).map(el => el.textContent?.trim());
         });
 
         expect(buttonTexts).toContain('New Call');
@@ -214,8 +215,9 @@ test.describe('Secondary Window', () => {
             const shell = document.querySelector('idispatch-app-shell');
             const win = shell?.shadowRoot?.querySelector('idispatch-secondary-window');
             const header = win?.shadowRoot?.querySelector('idispatch-window-header');
-            return Array.from(header?.shadowRoot?.querySelectorAll('button') ?? [])
-                .map(b => b.textContent?.trim());
+            // No buttons should be distributed into the actions slot
+            const actionsSlot = header?.shadowRoot?.querySelector('slot[name="actions"]') as HTMLSlotElement | null;
+            return (actionsSlot?.assignedElements() ?? []).map(el => el.textContent?.trim());
         });
 
         expect(buttonTexts).not.toContain('New Call');

--- a/Implementation/clients/dispatcher-client/e2e/launcher.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/launcher.spec.ts
@@ -191,6 +191,32 @@ test.describe('Launcher Page', () => {
         await dispatcherPage.close();
     });
 
+    test('sign-out propagates to open dispatcher windows via BroadcastChannel', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        // Open the primary window and wait for it to reach the authenticated state
+        const [dispatcherPage] = await Promise.all([
+            context.waitForEvent('page', { timeout: 10_000 }),
+            clickLauncherBtn(page, 'open-primary-btn'),
+        ]);
+        await dispatcherPage.waitForFunction(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            return !!shell?.shadowRoot?.querySelector('idispatch-primary-window');
+        }, { timeout: 20_000 });
+
+        // Trigger sign-out from the launcher
+        await clickLauncherBtn(page, 'launcher-btn-signout');
+
+        // The dispatcher window should immediately show the forced-logout screen
+        // without waiting for a token expiry or a 401 from the server.
+        await dispatcherPage.waitForFunction(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const loginScreen = shell?.shadowRoot?.querySelector('idispatch-login-screen');
+            return loginScreen?.getAttribute('status') === 'forced-logout';
+        }, { timeout: 8_000 });
+    });
+
     test('beforeunload guard is removed after all dispatcher windows are closed', async ({ page, context }) => {
         await loginViaKeycloak(page);
         await expectLauncherPage(page);

--- a/Implementation/clients/dispatcher-client/e2e/launcher.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/launcher.spec.ts
@@ -1,0 +1,217 @@
+// E2E tests for the Launcher Page and multi-window management.
+// Keycloak runs on port 8180 (started by globalSetup.ts).
+// Vite dev server runs on port 5173.
+
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+const APP_URL = 'http://localhost:5173/';
+const KEYCLOAK_ORIGIN = 'http://localhost:8180';
+
+const TEST_USER = 'test-dispatcher';
+const TEST_PASSWORD = 'Test1234!';
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+async function loginViaKeycloak(page: Page): Promise<void> {
+    await page.goto(APP_URL);
+    await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 10_000 });
+    await page.fill('input[name="username"]', TEST_USER);
+    await page.fill('input[name="password"]', TEST_PASSWORD);
+    await page.click('input[type="submit"], button[type="submit"]');
+}
+
+async function expectLauncherPage(page: Page): Promise<void> {
+    await page.waitForURL(APP_URL, { timeout: 10_000 });
+    await page.waitForFunction(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        return !!shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+    }, { timeout: 8_000 });
+}
+
+/** Returns the launcher page element from AppShell's shadow DOM. */
+async function getLauncherShadow(page: Page): Promise<{ shadow: ShadowRoot | null }> {
+    return page.evaluate(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+        return { shadow: launcher?.shadowRoot ?? null };
+    });
+}
+
+/** Clicks a button inside the launcher's shadow DOM by its class name. */
+async function clickLauncherBtn(page: Page, className: string): Promise<void> {
+    await page.evaluate((cls: string) => {
+        const shell = document.querySelector('idispatch-app-shell');
+        const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+        const btn = launcher?.shadowRoot?.querySelector(`.${cls}`) as HTMLElement | null;
+        btn?.click();
+    }, className);
+}
+
+// -------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------
+
+test.describe('Launcher Page', () => {
+
+    test('renders launcher card with expected buttons after login', async ({ page }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        // Both window-open buttons are present in the launcher's shadow DOM
+        const buttons = await page.evaluate(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+            const btns = Array.from(launcher?.shadowRoot?.querySelectorAll('button') ?? []);
+            return btns.map(b => b.textContent?.trim());
+        });
+
+        expect(buttons).toContain('Open Primary Window');
+        expect(buttons).toContain('Open Secondary Window');
+        expect(buttons).toContain('Sign Out');
+        expect(buttons).toContain('Account Management');
+    });
+
+    test('launcher shows current username', async ({ page }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const username = await page.evaluate(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+            return launcher?.shadowRoot?.querySelector('.launcher-username')?.textContent?.trim();
+        });
+
+        expect(username).toBe(TEST_USER);
+    });
+
+    test('opening primary window opens a new page at ?window=primary', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const [newPage] = await Promise.all([
+            context.waitForEvent('page', { timeout: 10_000 }),
+            clickLauncherBtn(page, 'open-primary-btn'),
+        ]);
+
+        await newPage.waitForLoadState('domcontentloaded');
+        expect(newPage.url()).toContain('window=primary');
+
+        await newPage.close();
+    });
+
+    test('opening secondary window opens a new page at ?window=secondary', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const [newPage] = await Promise.all([
+            context.waitForEvent('page', { timeout: 10_000 }),
+            clickLauncherBtn(page, 'open-secondary-btn'),
+        ]);
+
+        await newPage.waitForLoadState('domcontentloaded');
+        expect(newPage.url()).toContain('window=secondary');
+
+        await newPage.close();
+    });
+
+    test('clicking Open Primary Window a second time does not open a second window', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        // Open once
+        const [firstPage] = await Promise.all([
+            context.waitForEvent('page', { timeout: 10_000 }),
+            clickLauncherBtn(page, 'open-primary-btn'),
+        ]);
+        await firstPage.waitForLoadState('domcontentloaded');
+
+        const pageCountBefore = context.pages().length;
+
+        // Click again — should focus the existing window, not open a new one
+        await clickLauncherBtn(page, 'open-primary-btn');
+
+        // Allow a moment for any navigation or window.open to execute
+        await page.waitForTimeout(500);
+
+        expect(context.pages().length).toBe(pageCountBefore);
+
+        await firstPage.close();
+    });
+
+    test('after closing the primary window, opening it again succeeds', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        // Open and close
+        const [firstPage] = await Promise.all([
+            context.waitForEvent('page', { timeout: 10_000 }),
+            clickLauncherBtn(page, 'open-primary-btn'),
+        ]);
+        await firstPage.waitForLoadState('domcontentloaded');
+        await firstPage.close();
+
+        // Wait for the poll interval to detect the closed window (>1 s)
+        await page.waitForTimeout(1500);
+
+        // Open again
+        const [secondPage] = await Promise.all([
+            context.waitForEvent('page', { timeout: 10_000 }),
+            clickLauncherBtn(page, 'open-primary-btn'),
+        ]);
+        await secondPage.waitForLoadState('domcontentloaded');
+        expect(secondPage.url()).toContain('window=primary');
+
+        await secondPage.close();
+    });
+
+    test('beforeunload guard fires when a dispatcher window is open', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        // Open a primary window so the guard is armed
+        const [dispatcherPage] = await Promise.all([
+            context.waitForEvent('page', { timeout: 10_000 }),
+            clickLauncherBtn(page, 'open-primary-btn'),
+        ]);
+        await dispatcherPage.waitForLoadState('domcontentloaded');
+
+        // Dispatch a cancelable beforeunload event on the launcher and check
+        // that the launcher's handler sets defaultPrevented = true.
+        const wasCancelled = await page.evaluate(() => {
+            const event = new Event('beforeunload', { cancelable: true, bubbles: false });
+            window.dispatchEvent(event);
+            return event.defaultPrevented;
+        });
+
+        expect(wasCancelled).toBe(true);
+
+        await dispatcherPage.close();
+    });
+
+    test('beforeunload guard is removed after all dispatcher windows are closed', async ({ page, context }) => {
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const [dispatcherPage] = await Promise.all([
+            context.waitForEvent('page', { timeout: 10_000 }),
+            clickLauncherBtn(page, 'open-primary-btn'),
+        ]);
+        await dispatcherPage.waitForLoadState('domcontentloaded');
+        await dispatcherPage.close();
+
+        // Wait for the poll interval to detect closure and remove the guard
+        await page.waitForTimeout(1500);
+
+        const wasCancelled = await page.evaluate(() => {
+            const event = new Event('beforeunload', { cancelable: true, bubbles: false });
+            window.dispatchEvent(event);
+            return event.defaultPrevented;
+        });
+
+        expect(wasCancelled).toBe(false);
+    });
+
+});

--- a/Implementation/clients/dispatcher-client/src/main.ts
+++ b/Implementation/clients/dispatcher-client/src/main.ts
@@ -14,9 +14,20 @@ import { SessionManager } from './auth/SessionManager.ts';
 import { HttpClient } from './http/HttpClient.ts';
 import { AppShell } from './ui/AppShell.ts';
 import { LoginScreen } from './ui/LoginScreen.ts';
+import { WindowHeader, WindowFooter } from './ui/WindowChrome.ts';
+import { LauncherPage } from './ui/LauncherPage.ts';
+import { PrimaryWindow } from './ui/PrimaryWindow.ts';
+import { SecondaryWindow } from './ui/SecondaryWindow.ts';
+import { WINDOW_TYPE_KEY } from './ui/windowType.ts';
+import type { WindowType } from './ui/windowType.ts';
 
 // Register custom elements before any template or innerHTML usage
 customElements.define(LoginScreen.TAG, LoginScreen);
+customElements.define(WindowHeader.TAG, WindowHeader);
+customElements.define(WindowFooter.TAG, WindowFooter);
+customElements.define(LauncherPage.TAG, LauncherPage);
+customElements.define(PrimaryWindow.TAG, PrimaryWindow);
+customElements.define(SecondaryWindow.TAG, SecondaryWindow);
 customElements.define(AppShell.TAG, AppShell);
 
 async function boot(): Promise<void> {
@@ -24,6 +35,18 @@ async function boot(): Promise<void> {
     if (!appEl) {
         throw new Error('Missing #app element in index.html');
     }
+
+    // Determine the window type from the URL param, persisting it to sessionStorage
+    // so it survives the OIDC redirect that erases the query string.
+    const urlWindowType = new URLSearchParams(window.location.search).get('window');
+    if (urlWindowType === 'primary' || urlWindowType === 'secondary') {
+        sessionStorage.setItem(WINDOW_TYPE_KEY, urlWindowType);
+    }
+    const storedWindowType = sessionStorage.getItem(WINDOW_TYPE_KEY);
+    const windowType: WindowType =
+        storedWindowType === 'primary' ? 'primary' :
+        storedWindowType === 'secondary' ? 'secondary' :
+        'launcher';
 
     // Load runtime configuration
     const config = await loadAppConfig();
@@ -42,7 +65,7 @@ async function boot(): Promise<void> {
     // Mount the AppShell AFTER initialize() so that connectedCallback fires
     // with a fully wired authState — ensuring event listeners are registered.
     const shell = document.createElement(AppShell.TAG) as AppShell;
-    shell.initialize(authState, sessionManager);
+    shell.initialize(authState, sessionManager, windowType);
     appEl.appendChild(shell);
 
     // Expose authState for Playwright E2E tests in development mode

--- a/Implementation/clients/dispatcher-client/src/public/config.json
+++ b/Implementation/clients/dispatcher-client/src/public/config.json
@@ -1,6 +1,6 @@
 {
   "oidc": {
-    "issuer": "http://localhost:8080/realms/idispatchx",
+    "issuer": "http://localhost:8180/realms/idispatchx",
     "clientId": "dispatcher-client",
     "redirectUri": "http://localhost:5173/",
     "scopes": ["openid", "profile"],

--- a/Implementation/clients/dispatcher-client/src/styles/tokens.css
+++ b/Implementation/clients/dispatcher-client/src/styles/tokens.css
@@ -40,4 +40,14 @@
     /* Border radius */
     --radius-sm: 3px;
     --radius-md: 6px;
+
+    /* Window chrome */
+    --color-header-bg:     #2d2d30;   /* brighter than --color-bg-surface, VS Code title bar tone */
+    --color-header-border: #3e3e42;
+    --color-footer-bg:     #1a1a1c;   /* darker than --color-bg-base for status-bar feel */
+    --color-footer-border: #333336;
+    --color-header-text:   #e8e8e8;
+    --color-header-muted:  #b0b0b0;
+    --height-header:       48px;
+    --height-footer:       28px;
 }

--- a/Implementation/clients/dispatcher-client/src/ui/AppShell.css
+++ b/Implementation/clients/dispatcher-client/src/ui/AppShell.css
@@ -9,42 +9,6 @@
     height: 100%;
 }
 
-.app-content {
-    width: 100%;
-    height: 100%;
-}
-
-.app-toolbar {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: var(--space-sm);
-    padding: var(--space-sm) var(--space-md);
-    background: var(--color-bg-surface);
-    border-bottom: 1px solid var(--color-bg-border);
-    font-family: var(--font-family-ui);
-    font-size: var(--font-size-sm);
-}
-
-.toolbar-username {
-    color: var(--color-text-secondary);
-}
-
-.toolbar-sign-out {
-    background: none;
-    border: 1px solid var(--color-bg-border);
-    color: var(--color-text-primary);
-    border-radius: var(--radius-sm);
-    padding: 2px 10px;
-    font-size: var(--font-size-sm);
-    font-family: inherit;
-    cursor: pointer;
-}
-
-.toolbar-sign-out:hover {
-    background: var(--color-bg-base);
-}
-
 .session-warning {
     position: fixed;
     top: 0;

--- a/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
@@ -127,6 +127,12 @@ export class AppShell extends HTMLElement {
                 void this.#authState!.forceLogout('forced-logout');
             }
         };
+        // Announce to the launcher that this dispatcher window is authenticated.
+        // This lets the launcher arm its beforeunload guard even if it was
+        // refreshed while this window was still in its OIDC flow (and therefore
+        // hadn't written its sessionStorage flag yet at the time the launcher's
+        // connectedCallback ran).
+        this.#sessionChannel.postMessage({ type: 'window-authenticated', windowType: this.#windowType });
     }
 
     #closeSessionChannel(): void {

--- a/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
@@ -8,6 +8,7 @@ import type { AuthStatus } from '../auth/types.ts';
 import { LoginRequestedEvent, LoginScreen } from './LoginScreen.ts';
 import type { SessionManager } from '../auth/SessionManager.ts';
 import type { WindowType } from './windowType.ts';
+import { SESSION_CHANNEL_NAME } from './windowType.ts';
 import { LauncherPage } from './LauncherPage.ts';
 import { PrimaryWindow } from './PrimaryWindow.ts';
 import { SecondaryWindow } from './SecondaryWindow.ts';
@@ -24,6 +25,9 @@ export class AppShell extends HTMLElement {
     #sessionManager: SessionManager | null = null;
     #windowType: WindowType = 'launcher';
     #warningBanner: HTMLDivElement | null = null;
+    // BroadcastChannel used by dispatcher windows (primary/secondary) to receive
+    // session events from the launcher — notably sign-out propagation.
+    #sessionChannel: BroadcastChannel | null = null;
 
     // Bound handler references for removeEventListener
     #onAuthChanged: ((e: Event) => void) | null = null;
@@ -93,16 +97,41 @@ export class AppShell extends HTMLElement {
         if (this.#onLoginRequested) {
             this.#shadow.removeEventListener(LoginRequestedEvent.TYPE, this.#onLoginRequested);
         }
+        this.#closeSessionChannel();
     }
 
     #onStatusChanged(status: AuthStatus): void {
         if (status.kind === 'authenticated') {
             this.#sessionManager!.start();
+            // Dispatcher windows listen for session events from the launcher
+            // (e.g. sign-out) so they can respond immediately without waiting
+            // for a token expiry or a 401 from the server.
+            if (this.#windowType !== 'launcher') {
+                this.#openSessionChannel();
+            }
         } else if (status.kind === 'expired' || status.kind === 'unauthenticated') {
             this.#sessionManager!.stop();
             this.#dismissWarningBanner();
+            this.#closeSessionChannel();
         }
         this.#renderStatus(status);
+    }
+
+    #openSessionChannel(): void {
+        if (this.#sessionChannel) return;
+        this.#sessionChannel = new BroadcastChannel(SESSION_CHANNEL_NAME);
+        this.#sessionChannel.onmessage = (e: MessageEvent<{ type: string }>) => {
+            if (e.data.type === 'sign-out') {
+                // The launcher has initiated an OIDC logout. Show the signed-out
+                // overlay immediately rather than waiting for a 401.
+                void this.#authState!.forceLogout('forced-logout');
+            }
+        };
+    }
+
+    #closeSessionChannel(): void {
+        this.#sessionChannel?.close();
+        this.#sessionChannel = null;
     }
 
     #renderStatus(status: AuthStatus): void {

--- a/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/AppShell.ts
@@ -7,6 +7,10 @@ import { AuthChangedEvent, AuthState, SessionWarningEvent } from '../auth/AuthSt
 import type { AuthStatus } from '../auth/types.ts';
 import { LoginRequestedEvent, LoginScreen } from './LoginScreen.ts';
 import type { SessionManager } from '../auth/SessionManager.ts';
+import type { WindowType } from './windowType.ts';
+import { LauncherPage } from './LauncherPage.ts';
+import { PrimaryWindow } from './PrimaryWindow.ts';
+import { SecondaryWindow } from './SecondaryWindow.ts';
 
 /**
  * `<idispatch-app-shell>` Web Component.
@@ -18,6 +22,7 @@ export class AppShell extends HTMLElement {
     #shadow: ShadowRoot;
     #authState: AuthState | null = null;
     #sessionManager: SessionManager | null = null;
+    #windowType: WindowType = 'launcher';
     #warningBanner: HTMLDivElement | null = null;
 
     // Bound handler references for removeEventListener
@@ -34,9 +39,10 @@ export class AppShell extends HTMLElement {
      * Injects dependencies after the element is constructed.
      * Called by main.ts before the element is connected to the DOM.
      */
-    initialize(authState: AuthState, sessionManager: SessionManager): void {
+    initialize(authState: AuthState, sessionManager: SessionManager, windowType: WindowType): void {
         this.#authState = authState;
         this.#sessionManager = sessionManager;
+        this.#windowType = windowType;
     }
 
     connectedCallback(): void {
@@ -100,16 +106,14 @@ export class AppShell extends HTMLElement {
     }
 
     #renderStatus(status: AuthStatus): void {
-        // Remove any existing login screen
-        const existingLogin = this.#shadow.querySelector(LoginScreen.TAG);
-        if (existingLogin) {
-            existingLogin.remove();
-        }
-
-        // Remove any existing app content placeholder
-        const existingContent = this.#shadow.querySelector('.app-content');
-        if (existingContent) {
-            existingContent.remove();
+        // Remove any existing authenticated view or login screen
+        for (const tag of [
+            LoginScreen.TAG,
+            LauncherPage.TAG,
+            PrimaryWindow.TAG,
+            SecondaryWindow.TAG,
+        ]) {
+            this.#shadow.querySelector(tag)?.remove();
         }
 
         switch (status.kind) {
@@ -122,29 +126,30 @@ export class AppShell extends HTMLElement {
             }
 
             case 'authenticated': {
-                const content = document.createElement('div');
-                content.className = 'app-content';
-                content.setAttribute('data-username', status.tokenSet.parsedAccess.preferred_username ?? status.tokenSet.parsedAccess.sub);
+                const username =
+                    status.tokenSet.parsedAccess.preferred_username ??
+                    status.tokenSet.parsedAccess.sub;
 
-                const toolbar = document.createElement('div');
-                toolbar.className = 'app-toolbar';
-
-                const username = document.createElement('span');
-                username.className = 'toolbar-username';
-                username.textContent = status.tokenSet.parsedAccess.preferred_username ?? status.tokenSet.parsedAccess.sub;
-
-                const signOutBtn = document.createElement('button');
-                signOutBtn.className = 'toolbar-sign-out';
-                signOutBtn.setAttribute('type', 'button');
-                signOutBtn.textContent = 'Sign out';
-                signOutBtn.addEventListener('click', () => { void this.#authState!.logout(); });
-
-                toolbar.appendChild(username);
-                toolbar.appendChild(signOutBtn);
-                content.appendChild(toolbar);
-
-                // Placeholder: full dispatcher UI will be built here in future iterations
-                this.#shadow.appendChild(content);
+                switch (this.#windowType) {
+                    case 'launcher': {
+                        const launcher = document.createElement(LauncherPage.TAG) as LauncherPage;
+                        launcher.initialize(this.#authState!, username);
+                        this.#shadow.appendChild(launcher);
+                        break;
+                    }
+                    case 'primary': {
+                        const primary = document.createElement(PrimaryWindow.TAG) as PrimaryWindow;
+                        primary.initialize(username);
+                        this.#shadow.appendChild(primary);
+                        break;
+                    }
+                    case 'secondary': {
+                        const secondary = document.createElement(SecondaryWindow.TAG) as SecondaryWindow;
+                        secondary.initialize(username);
+                        this.#shadow.appendChild(secondary);
+                        break;
+                    }
+                }
                 break;
             }
 

--- a/Implementation/clients/dispatcher-client/src/ui/LauncherPage.css
+++ b/Implementation/clients/dispatcher-client/src/ui/LauncherPage.css
@@ -1,0 +1,110 @@
+/*
+ * Styles for <idispatch-launcher-page>.
+ * Full-viewport centered card layout.
+ */
+
+:host {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    background: var(--color-bg-base);
+    font-family: var(--font-family-ui);
+    color: var(--color-text-primary);
+    box-sizing: border-box;
+}
+
+.launcher-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-lg);
+    padding: var(--space-xl) var(--space-2xl);
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-bg-border);
+    border-radius: var(--radius-md);
+    min-width: 320px;
+}
+
+.launcher-logo {
+    width: 48px;
+    height: 48px;
+    background: var(--color-accent);
+    border-radius: var(--radius-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    font-weight: 700;
+    color: #fff;
+    letter-spacing: -0.5px;
+}
+
+.launcher-title {
+    margin: 0;
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+}
+
+.launcher-username {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+}
+
+.launcher-actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    width: 100%;
+}
+
+.launcher-btn {
+    width: 100%;
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-base);
+    font-family: inherit;
+    cursor: pointer;
+    border: 1px solid var(--color-bg-border);
+    background: var(--color-bg-base);
+    color: var(--color-text-primary);
+    text-align: left;
+}
+
+.launcher-btn:hover:not(:disabled) {
+    background: var(--color-bg-surface);
+    border-color: var(--color-accent);
+}
+
+.launcher-btn:active:not(:disabled) {
+    background: var(--color-accent-active);
+    border-color: var(--color-accent-active);
+}
+
+.launcher-btn:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.launcher-btn.primary-action {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+}
+
+.launcher-btn.primary-action:hover:not(:disabled) {
+    background: var(--color-accent-hover);
+    border-color: var(--color-accent-hover);
+}
+
+.launcher-btn.primary-action:active:not(:disabled) {
+    background: var(--color-accent-active);
+    border-color: var(--color-accent-active);
+}
+
+.launcher-divider {
+    width: 100%;
+    border: none;
+    border-top: 1px solid var(--color-bg-border);
+    margin: var(--space-xs) 0;
+}

--- a/Implementation/clients/dispatcher-client/src/ui/LauncherPage.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/LauncherPage.ts
@@ -4,6 +4,7 @@
 
 import STYLES from './LauncherPage.css?inline';
 import type { AuthState } from '../auth/AuthState.ts';
+import { SESSION_CHANNEL_NAME } from './windowType.ts';
 import { PRIMARY_WINDOW_OPEN_KEY } from './PrimaryWindow.ts';
 import { SECONDARY_WINDOW_OPEN_KEY } from './SecondaryWindow.ts';
 
@@ -43,6 +44,10 @@ export class LauncherPage extends HTMLElement {
     // beforeunload guard — registered when any dispatcher window is open
     #beforeUnloadHandler: ((e: BeforeUnloadEvent) => void) | null = null;
 
+    // BroadcastChannel used to propagate session events (e.g. sign-out) to all
+    // open dispatcher windows so they respond immediately.
+    #sessionChannel: BroadcastChannel | null = null;
+
     constructor() {
         super();
         this.#shadow = this.attachShadow({ mode: 'open' });
@@ -54,6 +59,10 @@ export class LauncherPage extends HTMLElement {
     }
 
     connectedCallback(): void {
+        // Open the broadcast channel so sign-out can be propagated to all open
+        // dispatcher windows the moment the user clicks Sign Out.
+        this.#sessionChannel = new BroadcastChannel(SESSION_CHANNEL_NAME);
+
         // If this launcher was refreshed while dispatcher windows were open, the
         // in-memory refs are gone but the sessionStorage flags remain (written by
         // the child windows via window.opener). Re-arm the beforeunload guard so
@@ -107,8 +116,14 @@ export class LauncherPage extends HTMLElement {
 
         const signOutBtn = this.#makeButton(
             'Sign Out',
-            'launcher-btn',
-            () => { void this.#authState?.logout(); },
+            'launcher-btn launcher-btn-signout',
+            () => {
+                // Notify all open dispatcher windows before redirecting so they
+                // can show the signed-out overlay immediately rather than waiting
+                // for a token expiry or a 401.
+                this.#sessionChannel?.postMessage({ type: 'sign-out' });
+                void this.#authState?.logout();
+            },
         );
 
         actions.append(openPrimaryBtn, openSecondaryBtn, divider, accountBtn, signOutBtn);
@@ -117,6 +132,8 @@ export class LauncherPage extends HTMLElement {
     }
 
     disconnectedCallback(): void {
+        this.#sessionChannel?.close();
+        this.#sessionChannel = null;
         this.#stopPolling();
         this.#unregisterBeforeUnload();
     }
@@ -127,28 +144,50 @@ export class LauncherPage extends HTMLElement {
 
     #openWindow(type: 'primary' | 'secondary'): void {
         const existingRef = type === 'primary' ? this.#primaryWindowRef : this.#secondaryWindowRef;
+        const windowName = `idispatch-${type}` as const;
+        const flagKey = type === 'primary' ? PRIMARY_WINDOW_OPEN_KEY : SECONDARY_WINDOW_OPEN_KEY;
 
-        // Layer 2: in-memory ref check — focus if already open
+        // Layer 2: in-memory ref check — focus if still open
         if (existingRef !== null && !existingRef.closed) {
             existingRef.focus();
             return;
         }
 
-        // Layer 1: named window target ensures the browser reuses the tab if the
-        // ref was lost (e.g. after a launcher page refresh)
-        const newWin = window.open(`?window=${type}`, `idispatch-${type}`, WINDOW_FEATURES);
+        // Layer 1: if the sessionStorage flag is set the window announced itself
+        // as open during this launcher session. The launcher may have been
+        // refreshed since, losing the in-memory ref. Probe with an empty URL to
+        // focus the window without navigating (reloading) it.
+        //
+        // The probe is guarded behind the flag so that the normal first-open path
+        // goes straight to window.open(url), avoiding a spurious about:blank popup
+        // that would otherwise appear and immediately be closed.
+        if (sessionStorage.getItem(flagKey) === '1') {
+            const probed = window.open('', windowName);
+            if (probed !== null && probed.location.href !== 'about:blank') {
+                // Existing window found — recover the ref and focus without reload
+                if (type === 'primary') this.#primaryWindowRef = probed;
+                else this.#secondaryWindowRef = probed;
+                probed.focus();
+                this.#registerBeforeUnload();
+                this.#startPolling();
+                return;
+            }
+            // Flag was stale (window crashed or closed without clearing it).
+            // Clean up and fall through to open a fresh window.
+            sessionStorage.removeItem(flagKey);
+            probed?.close();
+        }
 
+        // Open the real URL with the correct window features
+        const newWin = window.open(`?window=${type}`, windowName, WINDOW_FEATURES);
         if (newWin === null) {
             // Popup was blocked — the browser shows its own indicator
             console.warn(`[LauncherPage] Popup blocked for ${type} window`);
             return;
         }
 
-        if (type === 'primary') {
-            this.#primaryWindowRef = newWin;
-        } else {
-            this.#secondaryWindowRef = newWin;
-        }
+        if (type === 'primary') this.#primaryWindowRef = newWin;
+        else this.#secondaryWindowRef = newWin;
 
         this.#registerBeforeUnload();
         this.#startPolling();

--- a/Implementation/clients/dispatcher-client/src/ui/LauncherPage.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/LauncherPage.ts
@@ -59,16 +59,29 @@ export class LauncherPage extends HTMLElement {
     }
 
     connectedCallback(): void {
-        // Open the broadcast channel so sign-out can be propagated to all open
-        // dispatcher windows the moment the user clicks Sign Out.
         this.#sessionChannel = new BroadcastChannel(SESSION_CHANNEL_NAME);
 
-        // If this launcher was refreshed while dispatcher windows were open, the
-        // in-memory refs are gone but the sessionStorage flags remain (written by
-        // the child windows via window.opener). Re-arm the beforeunload guard so
-        // the dispatcher is still warned before accidentally closing the launcher.
+        // Listen for dispatcher windows announcing themselves. This handles the
+        // race where a window is still in its OIDC flow when connectedCallback
+        // runs — the flag is not yet written, so the initial check below would
+        // miss it. The message arrives once the window reaches authenticated state.
+        this.#sessionChannel.onmessage = (e: MessageEvent<{ type: string }>) => {
+            if (e.data.type === 'window-authenticated') {
+                this.#registerBeforeUnload();
+                this.#startPolling();
+            }
+        };
+
+        // Always register the beforeunload guard — it is a no-op when no windows
+        // are open because the handler checks #anyWindowOpen() before preventing
+        // navigation. Registering unconditionally avoids the race where the guard
+        // was never armed because no flag was set at load time.
+        this.#registerBeforeUnload();
+
+        // If windows were already open and authenticated before this load (flags
+        // set), start polling immediately so the guard is removed when they close.
         if (this.#anyWindowFlagSet()) {
-            this.#registerBeforeUnload();
+            this.#startPolling();
         }
 
         const style = document.createElement('style');

--- a/Implementation/clients/dispatcher-client/src/ui/LauncherPage.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/LauncherPage.ts
@@ -1,0 +1,252 @@
+// Launcher page Web Component — shown after login.
+// Provides actions to open the primary and secondary dispatcher windows,
+// sign out, and navigate to OIDC account management.
+
+import STYLES from './LauncherPage.css?inline';
+import type { AuthState } from '../auth/AuthState.ts';
+import { PRIMARY_WINDOW_OPEN_KEY } from './PrimaryWindow.ts';
+import { SECONDARY_WINDOW_OPEN_KEY } from './SecondaryWindow.ts';
+
+/** Feature string for window.open — no browser chrome, sized for Full HD monitors. */
+const WINDOW_FEATURES = 'width=1920,height=1080,menubar=no,toolbar=no,location=no,status=no';
+
+/** Polling interval (ms) to detect when a dispatcher window has been closed. */
+const CLOSED_POLL_INTERVAL_MS = 1000;
+
+/**
+ * `<idispatch-launcher-page>` Web Component.
+ *
+ * Single-instance enforcement uses three complementary layers:
+ *   1. Named window target in window.open() — browser reuses the same window.
+ *   2. In-memory Window ref + .closed check — detects closure within the session.
+ *   3. sessionStorage flags written by the child windows via window.opener — survives
+ *      a launcher page refresh that would otherwise clear the in-memory refs.
+ *
+ * Accidental-close protection: a beforeunload handler is registered on the launcher
+ * window whenever a dispatcher window is open. It triggers the browser's built-in
+ * "Leave site?" confirmation dialog to prevent inadvertent tab closure.
+ */
+export class LauncherPage extends HTMLElement {
+    static readonly TAG = 'idispatch-launcher-page' as const;
+
+    #shadow: ShadowRoot;
+    #authState: AuthState | null = null;
+    #username = '';
+
+    // Retained handles to opened windows; checked via .closed
+    #primaryWindowRef: Window | null = null;
+    #secondaryWindowRef: Window | null = null;
+
+    // Poll timer that nulls refs when windows are detected closed
+    #pollId: ReturnType<typeof setInterval> | null = null;
+
+    // beforeunload guard — registered when any dispatcher window is open
+    #beforeUnloadHandler: ((e: BeforeUnloadEvent) => void) | null = null;
+
+    constructor() {
+        super();
+        this.#shadow = this.attachShadow({ mode: 'open' });
+    }
+
+    initialize(authState: AuthState, username: string): void {
+        this.#authState = authState;
+        this.#username = username;
+    }
+
+    connectedCallback(): void {
+        // If this launcher was refreshed while dispatcher windows were open, the
+        // in-memory refs are gone but the sessionStorage flags remain (written by
+        // the child windows via window.opener). Re-arm the beforeunload guard so
+        // the dispatcher is still warned before accidentally closing the launcher.
+        if (this.#anyWindowFlagSet()) {
+            this.#registerBeforeUnload();
+        }
+
+        const style = document.createElement('style');
+        style.textContent = STYLES;
+
+        const card = document.createElement('div');
+        card.className = 'launcher-card';
+
+        const logo = document.createElement('div');
+        logo.className = 'launcher-logo';
+        logo.textContent = 'iD';
+        logo.setAttribute('aria-hidden', 'true');
+
+        const title = document.createElement('h1');
+        title.className = 'launcher-title';
+        title.textContent = 'iDispatchX';
+
+        const usernameEl = document.createElement('div');
+        usernameEl.className = 'launcher-username';
+        usernameEl.textContent = this.#username;
+
+        const actions = document.createElement('div');
+        actions.className = 'launcher-actions';
+
+        const openPrimaryBtn = this.#makeButton(
+            'Open Primary Window',
+            'launcher-btn primary-action open-primary-btn',
+            () => { this.#openWindow('primary'); },
+        );
+
+        const openSecondaryBtn = this.#makeButton(
+            'Open Secondary Window',
+            'launcher-btn primary-action open-secondary-btn',
+            () => { this.#openWindow('secondary'); },
+        );
+
+        const divider = document.createElement('hr');
+        divider.className = 'launcher-divider';
+
+        const accountBtn = this.#makeButton(
+            'Account Management',
+            'launcher-btn',
+            () => { this.#openAccountManagement(); },
+        );
+
+        const signOutBtn = this.#makeButton(
+            'Sign Out',
+            'launcher-btn',
+            () => { void this.#authState?.logout(); },
+        );
+
+        actions.append(openPrimaryBtn, openSecondaryBtn, divider, accountBtn, signOutBtn);
+        card.append(logo, title, usernameEl, actions);
+        this.#shadow.append(style, card);
+    }
+
+    disconnectedCallback(): void {
+        this.#stopPolling();
+        this.#unregisterBeforeUnload();
+    }
+
+    // -------------------------------------------------------------------------
+    // Window management
+    // -------------------------------------------------------------------------
+
+    #openWindow(type: 'primary' | 'secondary'): void {
+        const existingRef = type === 'primary' ? this.#primaryWindowRef : this.#secondaryWindowRef;
+
+        // Layer 2: in-memory ref check — focus if already open
+        if (existingRef !== null && !existingRef.closed) {
+            existingRef.focus();
+            return;
+        }
+
+        // Layer 1: named window target ensures the browser reuses the tab if the
+        // ref was lost (e.g. after a launcher page refresh)
+        const newWin = window.open(`?window=${type}`, `idispatch-${type}`, WINDOW_FEATURES);
+
+        if (newWin === null) {
+            // Popup was blocked — the browser shows its own indicator
+            console.warn(`[LauncherPage] Popup blocked for ${type} window`);
+            return;
+        }
+
+        if (type === 'primary') {
+            this.#primaryWindowRef = newWin;
+        } else {
+            this.#secondaryWindowRef = newWin;
+        }
+
+        this.#registerBeforeUnload();
+        this.#startPolling();
+    }
+
+    #openAccountManagement(): void {
+        const issuer = this.#authState?.getDiscovery()?.issuer;
+        if (issuer) {
+            window.open(`${issuer}/account`, '_blank', 'noopener,noreferrer');
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Polling — detects when child windows are closed
+    // -------------------------------------------------------------------------
+
+    #startPolling(): void {
+        if (this.#pollId !== null) return; // already running
+
+        this.#pollId = setInterval(() => {
+            if (this.#primaryWindowRef?.closed) {
+                this.#primaryWindowRef = null;
+            }
+            if (this.#secondaryWindowRef?.closed) {
+                this.#secondaryWindowRef = null;
+            }
+
+            // When all windows are confirmed closed, tear down guards
+            if (!this.#anyWindowOpen()) {
+                this.#stopPolling();
+                this.#unregisterBeforeUnload();
+            }
+        }, CLOSED_POLL_INTERVAL_MS);
+    }
+
+    #stopPolling(): void {
+        if (this.#pollId !== null) {
+            clearInterval(this.#pollId);
+            this.#pollId = null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // beforeunload guard — warns before accidental launcher closure
+    // -------------------------------------------------------------------------
+
+    #registerBeforeUnload(): void {
+        if (this.#beforeUnloadHandler) return; // already registered
+
+        this.#beforeUnloadHandler = (e: BeforeUnloadEvent) => {
+            if (this.#anyWindowOpen()) {
+                e.preventDefault();
+                // Assigning returnValue is required for compatibility with older browsers
+                // that do not respect preventDefault() alone.
+                e.returnValue = '';
+            }
+        };
+        window.addEventListener('beforeunload', this.#beforeUnloadHandler);
+    }
+
+    #unregisterBeforeUnload(): void {
+        if (this.#beforeUnloadHandler) {
+            window.removeEventListener('beforeunload', this.#beforeUnloadHandler);
+            this.#beforeUnloadHandler = null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Returns true if any dispatcher window is believed to be open. */
+    #anyWindowOpen(): boolean {
+        return (
+            (this.#primaryWindowRef !== null && !this.#primaryWindowRef.closed) ||
+            (this.#secondaryWindowRef !== null && !this.#secondaryWindowRef.closed) ||
+            this.#anyWindowFlagSet()
+        );
+    }
+
+    /**
+     * Checks the sessionStorage flags written by child windows via window.opener.
+     * Returns true if at least one flag is present, indicating a dispatcher window
+     * has announced itself in the current launcher session.
+     */
+    #anyWindowFlagSet(): boolean {
+        return (
+            sessionStorage.getItem(PRIMARY_WINDOW_OPEN_KEY) === '1' ||
+            sessionStorage.getItem(SECONDARY_WINDOW_OPEN_KEY) === '1'
+        );
+    }
+
+    #makeButton(text: string, className: string, onClick: () => void): HTMLButtonElement {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = className;
+        btn.textContent = text;
+        btn.addEventListener('click', onClick);
+        return btn;
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.css
+++ b/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.css
@@ -1,0 +1,20 @@
+/*
+ * Styles for <idispatch-primary-window>.
+ * Column flex layout: header (fixed) → body (fills remaining space) → footer (fixed).
+ */
+
+:host {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    box-sizing: border-box;
+}
+
+.window-body {
+    flex: 1;
+    background: var(--color-bg-base);
+    overflow: hidden;
+    /* Operational content (call/incident columns) will be placed here */
+}

--- a/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
@@ -1,0 +1,87 @@
+// Root Web Component for the primary dispatcher window.
+// Renders a header (with primary actions) and footer around an empty body placeholder.
+
+import STYLES from './PrimaryWindow.css?inline';
+import { WindowHeader, WindowFooter } from './WindowChrome.ts';
+
+/** localStorage key set by this window so the launcher can detect it is open. */
+export const PRIMARY_WINDOW_OPEN_KEY = 'idispatch:window:primary' as const;
+
+/**
+ * `<idispatch-primary-window>` Web Component.
+ *
+ * Full-viewport column flex: WindowHeader → .window-body → WindowFooter.
+ * The header includes "New Call" and "New Incident" action buttons.
+ */
+export class PrimaryWindow extends HTMLElement {
+    static readonly TAG = 'idispatch-primary-window' as const;
+
+    #shadow: ShadowRoot;
+    #username = '';
+    #onBeforeUnload: (() => void) | null = null;
+
+    constructor() {
+        super();
+        this.#shadow = this.attachShadow({ mode: 'open' });
+    }
+
+    initialize(username: string): void {
+        this.#username = username;
+    }
+
+    connectedCallback(): void {
+        // Signal to the launcher (via its sessionStorage, accessible as window.opener)
+        // that this window is open. Cleared on beforeunload.
+        this.#registerOpenFlag();
+
+        const style = document.createElement('style');
+        style.textContent = STYLES;
+
+        const header = document.createElement(WindowHeader.TAG) as WindowHeader;
+        header.showPrimaryActions = true;
+
+        const body = document.createElement('div');
+        body.className = 'window-body';
+
+        const footer = document.createElement(WindowFooter.TAG) as WindowFooter;
+        footer.username = this.#username;
+
+        this.#shadow.append(style, header, body, footer);
+    }
+
+    disconnectedCallback(): void {
+        this.#unregisterOpenFlag();
+    }
+
+    #registerOpenFlag(): void {
+        // Write to the opener's sessionStorage (same-origin, so this is permitted).
+        // This lets the launcher detect the window is open even after the launcher
+        // has been refreshed and lost its in-memory window reference.
+        try {
+            const opener = window.opener as Window | null;
+            if (opener && !opener.closed) {
+                opener.sessionStorage.setItem(PRIMARY_WINDOW_OPEN_KEY, '1');
+            }
+        } catch {
+            // window.opener may be null or cross-origin in some edge cases; ignore
+        }
+
+        this.#onBeforeUnload = () => { this.#unregisterOpenFlag(); };
+        window.addEventListener('beforeunload', this.#onBeforeUnload);
+    }
+
+    #unregisterOpenFlag(): void {
+        if (this.#onBeforeUnload) {
+            window.removeEventListener('beforeunload', this.#onBeforeUnload);
+            this.#onBeforeUnload = null;
+        }
+        try {
+            const opener = window.opener as Window | null;
+            if (opener && !opener.closed) {
+                opener.sessionStorage.removeItem(PRIMARY_WINDOW_OPEN_KEY);
+            }
+        } catch {
+            // ignore
+        }
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
@@ -38,7 +38,20 @@ export class PrimaryWindow extends HTMLElement {
         style.textContent = STYLES;
 
         const header = document.createElement(WindowHeader.TAG) as WindowHeader;
-        header.showPrimaryActions = true;
+
+        const newCallBtn = document.createElement('button');
+        newCallBtn.type = 'button';
+        newCallBtn.className = 'header-action-btn';
+        newCallBtn.textContent = 'New Call';
+        newCallBtn.slot = 'actions';
+
+        const newIncidentBtn = document.createElement('button');
+        newIncidentBtn.type = 'button';
+        newIncidentBtn.className = 'header-action-btn';
+        newIncidentBtn.textContent = 'New Incident';
+        newIncidentBtn.slot = 'actions';
+
+        header.append(newCallBtn, newIncidentBtn);
 
         const body = document.createElement('div');
         body.className = 'window-body';

--- a/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.css
+++ b/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.css
@@ -1,0 +1,20 @@
+/*
+ * Styles for <idispatch-secondary-window>.
+ * Column flex layout: header (fixed) → body (fills remaining space) → footer (fixed).
+ */
+
+:host {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    box-sizing: border-box;
+}
+
+.window-body {
+    flex: 1;
+    background: var(--color-bg-base);
+    overflow: hidden;
+    /* Map and unit dashboard will be placed here */
+}

--- a/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.ts
@@ -36,7 +36,6 @@ export class SecondaryWindow extends HTMLElement {
         style.textContent = STYLES;
 
         const header = document.createElement(WindowHeader.TAG) as WindowHeader;
-        header.showPrimaryActions = false;
 
         const body = document.createElement('div');
         body.className = 'window-body';

--- a/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.ts
@@ -1,0 +1,82 @@
+// Root Web Component for the secondary dispatcher window.
+// Renders a header (without primary actions) and footer around an empty body placeholder.
+
+import STYLES from './SecondaryWindow.css?inline';
+import { WindowHeader, WindowFooter } from './WindowChrome.ts';
+
+/** localStorage key set by this window so the launcher can detect it is open. */
+export const SECONDARY_WINDOW_OPEN_KEY = 'idispatch:window:secondary' as const;
+
+/**
+ * `<idispatch-secondary-window>` Web Component.
+ *
+ * Full-viewport column flex: WindowHeader → .window-body → WindowFooter.
+ * The header has no primary action buttons (those belong to the primary window).
+ */
+export class SecondaryWindow extends HTMLElement {
+    static readonly TAG = 'idispatch-secondary-window' as const;
+
+    #shadow: ShadowRoot;
+    #username = '';
+    #onBeforeUnload: (() => void) | null = null;
+
+    constructor() {
+        super();
+        this.#shadow = this.attachShadow({ mode: 'open' });
+    }
+
+    initialize(username: string): void {
+        this.#username = username;
+    }
+
+    connectedCallback(): void {
+        this.#registerOpenFlag();
+
+        const style = document.createElement('style');
+        style.textContent = STYLES;
+
+        const header = document.createElement(WindowHeader.TAG) as WindowHeader;
+        header.showPrimaryActions = false;
+
+        const body = document.createElement('div');
+        body.className = 'window-body';
+
+        const footer = document.createElement(WindowFooter.TAG) as WindowFooter;
+        footer.username = this.#username;
+
+        this.#shadow.append(style, header, body, footer);
+    }
+
+    disconnectedCallback(): void {
+        this.#unregisterOpenFlag();
+    }
+
+    #registerOpenFlag(): void {
+        try {
+            const opener = window.opener as Window | null;
+            if (opener && !opener.closed) {
+                opener.sessionStorage.setItem(SECONDARY_WINDOW_OPEN_KEY, '1');
+            }
+        } catch {
+            // ignore
+        }
+
+        this.#onBeforeUnload = () => { this.#unregisterOpenFlag(); };
+        window.addEventListener('beforeunload', this.#onBeforeUnload);
+    }
+
+    #unregisterOpenFlag(): void {
+        if (this.#onBeforeUnload) {
+            window.removeEventListener('beforeunload', this.#onBeforeUnload);
+            this.#onBeforeUnload = null;
+        }
+        try {
+            const opener = window.opener as Window | null;
+            if (opener && !opener.closed) {
+                opener.sessionStorage.removeItem(SECONDARY_WINDOW_OPEN_KEY);
+            }
+        } catch {
+            // ignore
+        }
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/ui/WindowChrome.css
+++ b/Implementation/clients/dispatcher-client/src/ui/WindowChrome.css
@@ -70,7 +70,7 @@
     white-space: nowrap;
 }
 
-.header-action-btn {
+::slotted(.header-action-btn) {
     background: var(--color-bg-surface);
     border: 1px solid var(--color-bg-border);
     color: var(--color-header-text);
@@ -82,11 +82,11 @@
     white-space: nowrap;
 }
 
-.header-action-btn:hover {
+::slotted(.header-action-btn:hover) {
     background: var(--color-bg-base);
 }
 
-.header-action-btn:active {
+::slotted(.header-action-btn:active) {
     background: var(--color-accent-active);
     border-color: var(--color-accent-active);
 }

--- a/Implementation/clients/dispatcher-client/src/ui/WindowChrome.css
+++ b/Implementation/clients/dispatcher-client/src/ui/WindowChrome.css
@@ -1,0 +1,121 @@
+/*
+ * Shared styles for <idispatch-window-header> and <idispatch-window-footer>.
+ * Each component injects this file into its own shadow DOM.
+ * :host(.window-header-host) / :host(.window-footer-host) scope the rules
+ * to the correct element via a class the component adds to itself in connectedCallback.
+ */
+
+/* ---- WindowHeader ---- */
+
+:host(.window-header-host) {
+    display: flex;
+    align-items: center;
+    height: var(--height-header);
+    min-height: var(--height-header);
+    background: var(--color-header-bg);
+    border-bottom: 1px solid var(--color-header-border);
+    font-family: var(--font-family-ui);
+    font-size: var(--font-size-base);
+    color: var(--color-header-text);
+    flex-shrink: 0;
+    padding: 0 var(--space-md);
+    gap: var(--space-md);
+    user-select: none;
+    box-sizing: border-box;
+}
+
+.header-left {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex: 1;
+    min-width: 0;
+}
+
+.header-center {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex: 0 0 auto;
+}
+
+.header-right {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex: 1;
+    justify-content: flex-end;
+}
+
+.brand-logo {
+    width: 28px;
+    height: 28px;
+    background: var(--color-accent);
+    border-radius: var(--radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 700;
+    color: #fff;
+    letter-spacing: -0.5px;
+    flex-shrink: 0;
+}
+
+.header-clock {
+    font-size: var(--font-size-sm);
+    color: var(--color-header-muted);
+    /* Tabular digits prevent layout shift on each second tick */
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.header-action-btn {
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-bg-border);
+    color: var(--color-header-text);
+    border-radius: var(--radius-sm);
+    padding: 3px var(--space-sm);
+    font-size: var(--font-size-sm);
+    font-family: inherit;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.header-action-btn:hover {
+    background: var(--color-bg-base);
+}
+
+.header-action-btn:active {
+    background: var(--color-accent-active);
+    border-color: var(--color-accent-active);
+}
+
+/* ---- WindowFooter ---- */
+
+:host(.window-footer-host) {
+    display: flex;
+    align-items: center;
+    height: var(--height-footer);
+    min-height: var(--height-footer);
+    background: var(--color-footer-bg);
+    border-top: 1px solid var(--color-footer-border);
+    font-family: var(--font-family-ui);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    flex-shrink: 0;
+    padding: 0 var(--space-md);
+    box-sizing: border-box;
+}
+
+.footer-left {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.footer-right {
+    flex: 0 0 auto;
+    color: var(--color-text-muted);
+}

--- a/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
@@ -4,18 +4,27 @@ import STYLES from './WindowChrome.css?inline';
 
 const HELSINKI_TZ = 'Europe/Helsinki';
 
-/** Formats a Date as "DD.MM.YYYY HH:mm:ss" in the Europe/Helsinki timezone, 24-hour clock. */
+// Reuse a single formatter instance — constructing Intl objects is expensive.
+// formatToParts() is used to assemble an explicit "DD.MM.YYYY HH:mm:ss" string
+// rather than relying on toLocaleString(), which can include locale-specific
+// literals (e.g. 'klo' in fi-FI) that diverge from the intended format.
+const HELSINKI_FORMATTER = new Intl.DateTimeFormat('fi-FI', {
+    timeZone: HELSINKI_TZ,
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+});
+
+/** Returns "DD.MM.YYYY HH:mm:ss" in the Europe/Helsinki timezone, 24-hour clock. */
 function formatHelsinki(date: Date): string {
-    return date.toLocaleString('fi-FI', {
-        timeZone: HELSINKI_TZ,
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hour12: false,
-    });
+    const parts = HELSINKI_FORMATTER.formatToParts(date);
+    const p = (type: Intl.DateTimeFormatPartTypes): string =>
+        parts.find(part => part.type === type)?.value ?? '00';
+    return `${p('day')}.${p('month')}.${p('year')} ${p('hour')}:${p('minute')}:${p('second')}`;
 }
 
 /**

--- a/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
@@ -40,15 +40,10 @@ export class WindowHeader extends HTMLElement {
     #shadow: ShadowRoot;
     #clockEl: HTMLSpanElement | null = null;
     #tickId: ReturnType<typeof setInterval> | null = null;
-    #showPrimaryActions = false;
 
     constructor() {
         super();
         this.#shadow = this.attachShadow({ mode: 'open' });
-    }
-
-    set showPrimaryActions(value: boolean) {
-        this.#showPrimaryActions = value;
     }
 
     connectedCallback(): void {
@@ -74,23 +69,13 @@ export class WindowHeader extends HTMLElement {
 
         left.append(logo, this.#clockEl);
 
-        // Center: primary actions (primary window only)
+        // Center: named slot for caller-provided action buttons
         const center = document.createElement('div');
         center.className = 'header-center';
 
-        if (this.#showPrimaryActions) {
-            const newCallBtn = document.createElement('button');
-            newCallBtn.type = 'button';
-            newCallBtn.className = 'header-action-btn';
-            newCallBtn.textContent = 'New Call';
-
-            const newIncidentBtn = document.createElement('button');
-            newIncidentBtn.type = 'button';
-            newIncidentBtn.className = 'header-action-btn';
-            newIncidentBtn.textContent = 'New Incident';
-
-            center.append(newCallBtn, newIncidentBtn);
-        }
+        const actionsSlot = document.createElement('slot');
+        actionsSlot.name = 'actions';
+        center.appendChild(actionsSlot);
 
         // Right: layout customization (placeholder — buttons added in a later iteration)
         const right = document.createElement('div');

--- a/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
@@ -1,0 +1,150 @@
+// Shared header and footer Web Components used by both the primary and secondary windows.
+
+import STYLES from './WindowChrome.css?inline';
+
+const HELSINKI_TZ = 'Europe/Helsinki';
+
+/** Formats a Date as "DD.MM.YYYY HH:mm:ss" in the Europe/Helsinki timezone, 24-hour clock. */
+function formatHelsinki(date: Date): string {
+    return date.toLocaleString('fi-FI', {
+        timeZone: HELSINKI_TZ,
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+    });
+}
+
+/**
+ * `<idispatch-window-header>` Web Component.
+ *
+ * Displays the application logo, a live clock (Europe/Helsinki, 24-hour), and
+ * optional primary action buttons. Set `showPrimaryActions = true` before the
+ * element is connected to render the "New Call" and "New Incident" buttons.
+ */
+export class WindowHeader extends HTMLElement {
+    static readonly TAG = 'idispatch-window-header' as const;
+
+    #shadow: ShadowRoot;
+    #clockEl: HTMLSpanElement | null = null;
+    #tickId: ReturnType<typeof setInterval> | null = null;
+    #showPrimaryActions = false;
+
+    constructor() {
+        super();
+        this.#shadow = this.attachShadow({ mode: 'open' });
+    }
+
+    set showPrimaryActions(value: boolean) {
+        this.#showPrimaryActions = value;
+    }
+
+    connectedCallback(): void {
+        // Add class before injecting shadow styles so :host(.window-header-host) matches
+        this.classList.add('window-header-host');
+
+        const style = document.createElement('style');
+        style.textContent = STYLES;
+
+        // Left: logo + live clock
+        const left = document.createElement('div');
+        left.className = 'header-left';
+
+        const logo = document.createElement('div');
+        logo.className = 'brand-logo';
+        logo.textContent = 'iD';
+        logo.setAttribute('aria-hidden', 'true');
+
+        this.#clockEl = document.createElement('span');
+        this.#clockEl.className = 'header-clock';
+        this.#clockEl.setAttribute('aria-live', 'off');
+        this.#clockEl.setAttribute('aria-label', 'Current date and time');
+
+        left.append(logo, this.#clockEl);
+
+        // Center: primary actions (primary window only)
+        const center = document.createElement('div');
+        center.className = 'header-center';
+
+        if (this.#showPrimaryActions) {
+            const newCallBtn = document.createElement('button');
+            newCallBtn.type = 'button';
+            newCallBtn.className = 'header-action-btn';
+            newCallBtn.textContent = 'New Call';
+
+            const newIncidentBtn = document.createElement('button');
+            newIncidentBtn.type = 'button';
+            newIncidentBtn.className = 'header-action-btn';
+            newIncidentBtn.textContent = 'New Incident';
+
+            center.append(newCallBtn, newIncidentBtn);
+        }
+
+        // Right: layout customization (placeholder — buttons added in a later iteration)
+        const right = document.createElement('div');
+        right.className = 'header-right';
+
+        this.#shadow.append(style, left, center, right);
+
+        // Start clock, then tick every second
+        this.#tick();
+        this.#tickId = setInterval(() => { this.#tick(); }, 1000);
+    }
+
+    disconnectedCallback(): void {
+        if (this.#tickId !== null) {
+            clearInterval(this.#tickId);
+            this.#tickId = null;
+        }
+    }
+
+    #tick(): void {
+        if (this.#clockEl) {
+            this.#clockEl.textContent = formatHelsinki(new Date());
+        }
+    }
+}
+
+/**
+ * `<idispatch-window-footer>` Web Component.
+ *
+ * Displays the current username on the left and the normal/degraded mode
+ * indicator on the right. Set `username` before or after connection.
+ */
+export class WindowFooter extends HTMLElement {
+    static readonly TAG = 'idispatch-window-footer' as const;
+
+    #shadow: ShadowRoot;
+    #usernameEl: HTMLSpanElement | null = null;
+
+    constructor() {
+        super();
+        this.#shadow = this.attachShadow({ mode: 'open' });
+    }
+
+    set username(value: string) {
+        if (this.#usernameEl) {
+            this.#usernameEl.textContent = value;
+        }
+    }
+
+    connectedCallback(): void {
+        this.classList.add('window-footer-host');
+
+        const style = document.createElement('style');
+        style.textContent = STYLES;
+
+        this.#usernameEl = document.createElement('span');
+        this.#usernameEl.className = 'footer-left';
+
+        const modeEl = document.createElement('span');
+        modeEl.className = 'footer-right';
+        // Placeholder — actual degraded-mode detection is added in a later iteration
+        modeEl.textContent = 'Normal';
+
+        this.#shadow.append(style, this.#usernameEl, modeEl);
+    }
+}

--- a/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
@@ -119,6 +119,8 @@ export class WindowFooter extends HTMLElement {
 
     #shadow: ShadowRoot;
     #usernameEl: HTMLSpanElement | null = null;
+    // Buffers the value set before connectedCallback creates the element
+    #pendingUsername = '';
 
     constructor() {
         super();
@@ -126,6 +128,7 @@ export class WindowFooter extends HTMLElement {
     }
 
     set username(value: string) {
+        this.#pendingUsername = value;
         if (this.#usernameEl) {
             this.#usernameEl.textContent = value;
         }
@@ -139,6 +142,7 @@ export class WindowFooter extends HTMLElement {
 
         this.#usernameEl = document.createElement('span');
         this.#usernameEl.className = 'footer-left';
+        this.#usernameEl.textContent = this.#pendingUsername;
 
         const modeEl = document.createElement('span');
         modeEl.className = 'footer-right';

--- a/Implementation/clients/dispatcher-client/src/ui/windowType.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/windowType.ts
@@ -1,0 +1,8 @@
+// Shared window type constants — kept in a separate file to avoid circular
+// imports between main.ts (which registers components) and AppShell.ts
+// (which imports components and main.ts).
+
+export type WindowType = 'launcher' | 'primary' | 'secondary';
+
+/** sessionStorage key used to persist the window type across OIDC redirects. */
+export const WINDOW_TYPE_KEY = 'idispatch:windowType';

--- a/Implementation/clients/dispatcher-client/src/ui/windowType.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/windowType.ts
@@ -6,3 +6,9 @@ export type WindowType = 'launcher' | 'primary' | 'secondary';
 
 /** sessionStorage key used to persist the window type across OIDC redirects. */
 export const WINDOW_TYPE_KEY = 'idispatch:windowType';
+
+/**
+ * BroadcastChannel name for session-level coordination between the launcher
+ * and open dispatcher windows (e.g. sign-out propagation).
+ */
+export const SESSION_CHANNEL_NAME = 'idispatch-session';


### PR DESCRIPTION
## Summary

- Replaces the post-login placeholder with a **Launcher Page** — a centered card with buttons to open the primary window, secondary window, OIDC account management, and sign out
- Adds a **Primary Window** (new browser window) with a header (logo, live Helsinki clock, New Call / New Incident buttons) and footer (username, Normal mode indicator)
- Adds a **Secondary Window** (new browser window) with the same header/footer structure but without the primary action buttons
- Implements single-instance enforcement and accidental-close protection for the launcher (see details below)
- Adds 17 new E2E tests across two new spec files; all 30 E2E tests pass

Window bodies are intentionally empty — operational content (call/incident columns, map, unit dashboard) comes in later iterations.

## Architecture notes

**Window type routing** — `window.open('?window=primary', 'idispatch-primary', ...)` opens the new tab at the same origin. Because the OIDC redirect erases the query string, `main.ts` stores the window type to `sessionStorage` before auth starts and reads it back after. `AppShell` then renders the correct component based on the stored type.

**Single-instance enforcement** uses three layers:
1. Named `window.open()` target (`idispatch-primary` / `idispatch-secondary`) — the browser reuses the same window if already open
2. In-memory `Window` ref with `.closed` check — the launcher focuses the existing window instead of opening a new one
3. `sessionStorage` flags written by child windows via `window.opener` — survives a launcher page refresh that would otherwise clear the in-memory refs

**Accidental-close protection** — a `beforeunload` handler is registered on the launcher whenever a dispatcher window is open. It triggers the browser's built-in "Leave site?" dialog. The handler is removed when all windows are confirmed closed (via a 1 s polling loop).

**`WindowFooter` pre-connection fix** — a `#pendingUsername` buffer is used to hold values set before `connectedCallback`, following the standard Web Component property-before-connection pattern.

## Manual test plan

### Prerequisites

1. Start Keycloak and the Vite dev server:
   ```
   cd Implementation/clients/dispatcher-client
   npm run dev
   ```
2. Navigate to `http://localhost:5173/` and log in with the test credentials (`test-dispatcher` / `Test1234!`) or your configured OIDC user.

### Launcher Page

- [x] After login you land on the Launcher Page — a centred card with the iD logo, your username, and four buttons: **Open Primary Window**, **Open Secondary Window**, **Account Management**, **Sign Out**
- [x] **Sign Out** triggers the OIDC logout flow and returns you to the Keycloak login page
- [x] **Account Management** opens the Keycloak account page in a new tab

### Primary Window

- [x] Clicking **Open Primary Window** opens a new browser window
- [x] The new window has a header with the iD logo, a live clock in `DD.MM.YYYY HH:mm:ss` format (Europe/Helsinki timezone, 24-hour), and **New Call** / **New Incident** buttons in the centre
- [x] The clock updates every second
- [x] The footer shows your username on the left and **Normal** on the right

### Secondary Window

- [x] Clicking **Open Secondary Window** opens a new browser window
- [x] Header has logo and clock; **no** New Call / New Incident buttons in the centre
- [x] Footer shows your username and **Normal**

### Single-instance enforcement

- [x] With the primary window open, clicking **Open Primary Window** again brings the existing window to focus — no second window opens
- [x] Close the primary window, then click **Open Primary Window** — a new window opens successfully
- [x] Same behaviour for the secondary window

### Accidental-close protection

- [x] With a dispatcher window open, attempt to close the **launcher** tab (Ctrl+W / Cmd+W, or the × button) — the browser shows a **"Leave site?"** confirmation dialog
- [x] Confirm leaving — the tab closes
- [x] With no dispatcher windows open, closing the launcher tab does **not** show the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)