### PR TITLE
Dispatcher Client: internationalise hard-coded UI strings

### DIFF
--- a/Implementation/clients/dispatcher-client/e2e/i18n.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/i18n.spec.ts
@@ -23,13 +23,6 @@ async function setLocaleInStorage(page: Page, locale: string): Promise<void> {
     );
 }
 
-async function clearLocaleFromStorage(page: Page): Promise<void> {
-    await page.addInitScript(
-        (key: string) => { localStorage.removeItem(key); },
-        LOCALE_KEY,
-    );
-}
-
 async function loginViaKeycloak(page: Page): Promise<void> {
     await page.goto(APP_URL);
     await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 10_000 });
@@ -120,7 +113,6 @@ async function getLoginScreenTexts(page: Page): Promise<{ message: string; butto
 test.describe('i18n — locale selection and UI string localisation', () => {
 
     test('2.1 — default locale is English when no locale is stored', async ({ page }) => {
-        await clearLocaleFromStorage(page);
         await loginViaKeycloak(page);
         await expectLauncherPage(page);
 
@@ -210,7 +202,6 @@ test.describe('i18n — locale selection and UI string localisation', () => {
     });
 
     test('2.5 — selected locale persists across a page reload', async ({ page }) => {
-        await clearLocaleFromStorage(page);
         await loginViaKeycloak(page);
         await expectLauncherPage(page);
 
@@ -235,7 +226,6 @@ test.describe('i18n — locale selection and UI string localisation', () => {
     });
 
     test('2.6 — language selector renders with the active locale marked', async ({ page }) => {
-        await clearLocaleFromStorage(page);
         await loginViaKeycloak(page);
         await expectLauncherPage(page);
 
@@ -275,7 +265,6 @@ test.describe('i18n — locale selection and UI string localisation', () => {
     });
 
     test('2.7 — clicking a language button triggers a reload and applies the new locale', async ({ page }) => {
-        await clearLocaleFromStorage(page);
         await loginViaKeycloak(page);
         await expectLauncherPage(page);
 
@@ -297,7 +286,6 @@ test.describe('i18n — locale selection and UI string localisation', () => {
     });
 
     test('2.8 — login screen strings are localised (English default)', async ({ page }) => {
-        await clearLocaleFromStorage(page);
         await loginViaKeycloak(page);
         await expectLauncherPage(page);
 

--- a/Implementation/clients/dispatcher-client/e2e/i18n.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/i18n.spec.ts
@@ -1,0 +1,333 @@
+// E2E tests for the i18n mechanism (locale selection, persistence, and
+// translated UI strings across all affected components).
+//
+// Each test that depends on a specific locale sets localStorage directly
+// before navigation so that the i18n module reads the correct value on load.
+
+import { expect, test, type Page } from '@playwright/test';
+
+const APP_URL = 'http://localhost:5173/';
+const KEYCLOAK_ORIGIN = 'http://localhost:8180';
+const TEST_USER = 'test-dispatcher';
+const TEST_PASSWORD = 'Test1234!';
+const LOCALE_KEY = 'idispatch:locale';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function setLocaleInStorage(page: Page, locale: string): Promise<void> {
+    await page.addInitScript(
+        ({ key, value }: { key: string; value: string }) => { localStorage.setItem(key, value); },
+        { key: LOCALE_KEY, value: locale },
+    );
+}
+
+async function clearLocaleFromStorage(page: Page): Promise<void> {
+    await page.addInitScript(
+        (key: string) => { localStorage.removeItem(key); },
+        LOCALE_KEY,
+    );
+}
+
+async function loginViaKeycloak(page: Page): Promise<void> {
+    await page.goto(APP_URL);
+    await page.waitForURL(`${KEYCLOAK_ORIGIN}/**`, { timeout: 10_000 });
+    await page.fill('input[name="username"]', TEST_USER);
+    await page.fill('input[name="password"]', TEST_PASSWORD);
+    await page.click('input[type="submit"], button[type="submit"]');
+}
+
+async function expectLauncherPage(page: Page): Promise<void> {
+    await page.waitForURL(APP_URL, { timeout: 10_000 });
+    await page.waitForFunction(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        return !!shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+    }, { timeout: 8_000 });
+}
+
+/** Returns all button text values inside the launcher's shadow DOM. */
+async function getLauncherButtonLabels(page: Page): Promise<(string | undefined)[]> {
+    return page.evaluate(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+        return Array.from(launcher?.shadowRoot?.querySelectorAll('button') ?? [])
+            .map(b => b.textContent?.trim());
+    });
+}
+
+/** Returns the text of the footer mode indicator in the primary window. */
+async function getPrimaryWindowFooterMode(page: Page): Promise<string> {
+    return page.evaluate(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        const win = shell?.shadowRoot?.querySelector('idispatch-primary-window');
+        const footer = win?.shadowRoot?.querySelector('idispatch-window-footer');
+        return footer?.shadowRoot?.querySelector('.footer-right')?.textContent?.trim() ?? '';
+    });
+}
+
+/** Returns the text labels of primary action buttons in the primary window header. */
+async function getPrimaryWindowActionLabels(page: Page): Promise<(string | undefined)[]> {
+    return page.evaluate(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        const win = shell?.shadowRoot?.querySelector('idispatch-primary-window');
+        return Array.from(win?.shadowRoot?.querySelectorAll('.header-action-btn') ?? [])
+            .map(b => b.textContent?.trim());
+    });
+}
+
+async function openPrimaryWindow(page: Page): Promise<Page> {
+    const [newPage] = await Promise.all([
+        page.context().waitForEvent('page', { timeout: 10_000 }),
+        page.evaluate(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+            const btn = launcher?.shadowRoot?.querySelector('.open-primary-btn') as HTMLElement | null;
+            btn?.click();
+        }),
+    ]);
+    await newPage.waitForFunction(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        return !!shell?.shadowRoot?.querySelector('idispatch-primary-window');
+    }, { timeout: 20_000 });
+    return newPage;
+}
+
+async function simulateForceLogout(page: Page, reason: string): Promise<void> {
+    await page.waitForFunction(() => {
+        return !!(window as Window & { __authState?: unknown }).__authState;
+    }, { timeout: 5_000 });
+    await page.evaluate((r: string) => {
+        const w = window as Window & { __authState?: { forceLogout(reason: string): void } };
+        w.__authState?.forceLogout(r);
+    }, reason);
+}
+
+async function getLoginScreenTexts(page: Page): Promise<{ message: string; buttonLabel: string }> {
+    return page.evaluate(() => {
+        const shell = document.querySelector('idispatch-app-shell');
+        const loginScreen = shell?.shadowRoot?.querySelector('idispatch-login-screen');
+        const message = loginScreen?.shadowRoot?.querySelector('.status-message')?.textContent?.trim() ?? '';
+        const buttonLabel = loginScreen?.shadowRoot?.querySelector('.sign-in-button')?.textContent?.trim() ?? '';
+        return { message, buttonLabel };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('i18n — locale selection and UI string localisation', () => {
+
+    test('2.1 — default locale is English when no locale is stored', async ({ page }) => {
+        await clearLocaleFromStorage(page);
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const storedLocale = await page.evaluate((key: string) => localStorage.getItem(key), LOCALE_KEY);
+        // The module treats absence as 'en'; it does not write a default value back
+        expect(storedLocale === null || storedLocale === 'en').toBe(true);
+
+        const buttons = await getLauncherButtonLabels(page);
+        expect(buttons).toContain('Open Primary Window');
+        expect(buttons).toContain('Open Secondary Window');
+        expect(buttons).toContain('Account Management');
+        expect(buttons).toContain('Sign Out');
+    });
+
+    test('2.2 — unrecognised locale falls back to English', async ({ page }) => {
+        await setLocaleInStorage(page, 'xx');
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const buttons = await getLauncherButtonLabels(page);
+        expect(buttons).toContain('Open Primary Window');
+        expect(buttons).toContain('Open Secondary Window');
+        expect(buttons).toContain('Account Management');
+        expect(buttons).toContain('Sign Out');
+    });
+
+    test('2.3 — Finnish locale renders Finnish labels on the launcher', async ({ page }) => {
+        await setLocaleInStorage(page, 'fi');
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const buttons = await getLauncherButtonLabels(page);
+        expect(buttons).toContain('Avaa ensisijainen ikkuna');
+        expect(buttons).toContain('Avaa toissijainen ikkuna');
+        expect(buttons).toContain('Tilin hallinta');
+        expect(buttons).toContain('Kirjaudu ulos');
+
+        // The stored locale must not have been overwritten
+        const storedLocale = await page.evaluate((key: string) => localStorage.getItem(key), LOCALE_KEY);
+        expect(storedLocale).toBe('fi');
+    });
+
+    test('2.3 — Finnish locale renders Finnish labels in the primary window', async ({ page }) => {
+        await setLocaleInStorage(page, 'fi');
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const primaryPage = await openPrimaryWindow(page);
+
+        const actionLabels = await getPrimaryWindowActionLabels(primaryPage);
+        expect(actionLabels).toContain('Uusi puhelu');
+        expect(actionLabels).toContain('Uusi tehtävä');
+
+        const footerMode = await getPrimaryWindowFooterMode(primaryPage);
+        expect(footerMode).toBe('Normaali');
+
+        await primaryPage.close();
+    });
+
+    test('2.4 — Swedish locale renders Swedish labels on the launcher', async ({ page }) => {
+        await setLocaleInStorage(page, 'sv');
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const buttons = await getLauncherButtonLabels(page);
+        expect(buttons).toContain('Öppna primärt fönster');
+        expect(buttons).toContain('Öppna sekundärt fönster');
+        expect(buttons).toContain('Kontohantering');
+        expect(buttons).toContain('Logga ut');
+    });
+
+    test('2.4 — Swedish locale renders Swedish labels in the primary window', async ({ page }) => {
+        await setLocaleInStorage(page, 'sv');
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const primaryPage = await openPrimaryWindow(page);
+
+        const actionLabels = await getPrimaryWindowActionLabels(primaryPage);
+        expect(actionLabels).toContain('Nytt samtal');
+        expect(actionLabels).toContain('Nytt uppdrag');
+
+        const footerMode = await getPrimaryWindowFooterMode(primaryPage);
+        expect(footerMode).toBe('Normal');
+
+        await primaryPage.close();
+    });
+
+    test('2.5 — selected locale persists across a page reload', async ({ page }) => {
+        await clearLocaleFromStorage(page);
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        // Switch to Finnish via the language selector; this triggers a reload
+        await page.evaluate(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+            const fiBtn = launcher?.shadowRoot?.querySelector<HTMLButtonElement>('.lang-btn[lang="fi"]');
+            fiBtn?.click();
+        });
+
+        // Wait for the reload to settle back on the launcher
+        await expectLauncherPage(page);
+
+        // Finnish labels must be shown without any manual localStorage setup
+        const buttons = await getLauncherButtonLabels(page);
+        expect(buttons).toContain('Avaa ensisijainen ikkuna');
+
+        // The locale must still be persisted
+        const storedLocale = await page.evaluate((key: string) => localStorage.getItem(key), LOCALE_KEY);
+        expect(storedLocale).toBe('fi');
+    });
+
+    test('2.6 — language selector renders with the active locale marked', async ({ page }) => {
+        await clearLocaleFromStorage(page);
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        const selectorState = await page.evaluate(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+            const shadow = launcher?.shadowRoot;
+            if (!shadow) return null;
+
+            const langBtns = Array.from(shadow.querySelectorAll<HTMLButtonElement>('.lang-btn'));
+            return langBtns.map(btn => ({
+                lang: btn.getAttribute('lang'),
+                label: btn.textContent?.trim(),
+                isActive: btn.classList.contains('lang-btn-active'),
+                ariaCurrent: btn.getAttribute('aria-current'),
+            }));
+        });
+
+        expect(selectorState).not.toBeNull();
+        expect(selectorState).toHaveLength(3);
+
+        const fi = selectorState!.find(b => b.lang === 'fi');
+        const sv = selectorState!.find(b => b.lang === 'sv');
+        const en = selectorState!.find(b => b.lang === 'en');
+
+        expect(fi).toBeDefined();
+        expect(sv).toBeDefined();
+        expect(en).toBeDefined();
+
+        // English is the default active locale
+        expect(en!.isActive).toBe(true);
+        expect(en!.ariaCurrent).toBe('true');
+
+        // The other two must not be marked active
+        expect(fi!.isActive).toBe(false);
+        expect(sv!.isActive).toBe(false);
+    });
+
+    test('2.7 — clicking a language button triggers a reload and applies the new locale', async ({ page }) => {
+        await clearLocaleFromStorage(page);
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        // Click the Swedish button
+        await page.evaluate(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            const launcher = shell?.shadowRoot?.querySelector('idispatch-launcher-page');
+            const svBtn = launcher?.shadowRoot?.querySelector<HTMLButtonElement>('.lang-btn[lang="sv"]');
+            svBtn?.click();
+        });
+
+        // Wait for the reload to settle
+        await expectLauncherPage(page);
+
+        // Swedish labels must be shown
+        const buttons = await getLauncherButtonLabels(page);
+        expect(buttons).toContain('Öppna primärt fönster');
+        expect(buttons).toContain('Logga ut');
+    });
+
+    test('2.8 — login screen strings are localised (English default)', async ({ page }) => {
+        await clearLocaleFromStorage(page);
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        await simulateForceLogout(page, 'forced-logout');
+
+        await page.waitForFunction(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            return shell?.shadowRoot?.querySelector('idispatch-login-screen') !== null;
+        }, { timeout: 5_000 });
+
+        const { message, buttonLabel } = await getLoginScreenTexts(page);
+        expect(message.toLowerCase()).toContain('signed out');
+        expect(buttonLabel).toBe('Sign in again');
+    });
+
+    test('2.8 — login screen strings are localised (Finnish)', async ({ page }) => {
+        await setLocaleInStorage(page, 'fi');
+        await loginViaKeycloak(page);
+        await expectLauncherPage(page);
+
+        await simulateForceLogout(page, 'forced-logout');
+
+        await page.waitForFunction(() => {
+            const shell = document.querySelector('idispatch-app-shell');
+            return shell?.shadowRoot?.querySelector('idispatch-login-screen') !== null;
+        }, { timeout: 5_000 });
+
+        const { message, buttonLabel } = await getLoginScreenTexts(page);
+        expect(message).toBe('Sinut on kirjattu ulos.');
+        expect(buttonLabel).toBe('Kirjaudu uudelleen');
+    });
+
+});

--- a/Implementation/clients/dispatcher-client/e2e/launcher.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/launcher.spec.ts
@@ -57,12 +57,9 @@ async function clickLauncherBtn(page: Page, className: string): Promise<void> {
 test.describe('Launcher Page', () => {
 
     test('renders launcher card with expected buttons after login', async ({ page }) => {
-        // No locale is set — English default is active, so English labels are expected.
-        // If this test is changed to run under a different locale, the expected strings
-        // must be updated to match the corresponding translation table in src/i18n/index.ts.
-        await page.context().clearCookies();
-        await page.evaluate(() => localStorage.removeItem('idispatch:locale'));
-
+        // No locale is pre-set; each test gets a fresh browser context with empty localStorage,
+        // so the English default is active. If this test is run under a different locale the
+        // expected strings must match the corresponding entry in src/i18n/index.ts.
         await loginViaKeycloak(page);
         await expectLauncherPage(page);
 

--- a/Implementation/clients/dispatcher-client/e2e/launcher.spec.ts
+++ b/Implementation/clients/dispatcher-client/e2e/launcher.spec.ts
@@ -57,6 +57,12 @@ async function clickLauncherBtn(page: Page, className: string): Promise<void> {
 test.describe('Launcher Page', () => {
 
     test('renders launcher card with expected buttons after login', async ({ page }) => {
+        // No locale is set — English default is active, so English labels are expected.
+        // If this test is changed to run under a different locale, the expected strings
+        // must be updated to match the corresponding translation table in src/i18n/index.ts.
+        await page.context().clearCookies();
+        await page.evaluate(() => localStorage.removeItem('idispatch:locale'));
+
         await loginViaKeycloak(page);
         await expectLauncherPage(page);
 

--- a/Implementation/clients/dispatcher-client/src/i18n/index.ts
+++ b/Implementation/clients/dispatcher-client/src/i18n/index.ts
@@ -1,0 +1,125 @@
+// Internationalisation module for Dispatcher Client.
+//
+// Supported locales: English (en), Finnish (fi), Swedish (sv).
+// English is the fallback when a translation key is absent in the active locale.
+//
+// Locale is persisted in localStorage so it survives logout and page reload.
+// Changing the locale triggers a full page reload (acceptable per NFR and UX guidelines).
+
+export type Locale = 'en' | 'fi' | 'sv';
+
+const LOCALE_STORAGE_KEY = 'idispatch:locale';
+
+const SUPPORTED_LOCALES: ReadonlySet<string> = new Set<Locale>(['en', 'fi', 'sv']);
+
+// ---------------------------------------------------------------------------
+// Translation key catalogue
+// ---------------------------------------------------------------------------
+
+export type TranslationKey =
+    | 'launcher.openPrimaryWindow'
+    | 'launcher.openSecondaryWindow'
+    | 'launcher.accountManagement'
+    | 'launcher.signOut'
+    | 'launcher.language'
+    | 'primaryWindow.newCall'
+    | 'primaryWindow.newIncident'
+    | 'footer.normalMode'
+    | 'login.signingIn'
+    | 'login.sessionExpired'
+    | 'login.idleTimeout'
+    | 'login.maxLifetime'
+    | 'login.forcedLogout'
+    | 'login.signInAgain';
+
+type Translations = Record<TranslationKey, string>;
+
+// ---------------------------------------------------------------------------
+// Translation tables
+// ---------------------------------------------------------------------------
+
+const EN: Translations = {
+    'launcher.openPrimaryWindow':   'Open Primary Window',
+    'launcher.openSecondaryWindow': 'Open Secondary Window',
+    'launcher.accountManagement':   'Account Management',
+    'launcher.signOut':             'Sign Out',
+    'launcher.language':            'Language',
+    'primaryWindow.newCall':        'New Call',
+    'primaryWindow.newIncident':    'New Incident',
+    'footer.normalMode':            'Normal',
+    // NOTE: the word "inactivity" in the idle-timeout string is load-bearing —
+    // auth.spec.ts asserts that the message contains this word.
+    'login.signingIn':              'Signing in\u2026',
+    'login.sessionExpired':         'You have been signed out.',
+    'login.idleTimeout':            'You were signed out due to inactivity.',
+    'login.maxLifetime':            'Your session has reached its maximum duration.',
+    'login.forcedLogout':           'You have been signed out.',
+    'login.signInAgain':            'Sign in again',
+};
+
+const FI: Translations = {
+    'launcher.openPrimaryWindow':   'Avaa ensisijainen ikkuna',
+    'launcher.openSecondaryWindow': 'Avaa toissijainen ikkuna',
+    'launcher.accountManagement':   'Tilin hallinta',
+    'launcher.signOut':             'Kirjaudu ulos',
+    'launcher.language':            'Kieli',
+    'primaryWindow.newCall':        'Uusi puhelu',
+    'primaryWindow.newIncident':    'Uusi tehtävä',
+    'footer.normalMode':            'Normaali',
+    'login.signingIn':              'Kirjaudutaan sisään\u2026',
+    'login.sessionExpired':         'Sinut on kirjattu ulos.',
+    'login.idleTimeout':            'Sinut kirjattiin ulos passiivisuuden vuoksi.',
+    'login.maxLifetime':            'Istuntosi on saavuttanut enimmäiskestonsa.',
+    'login.forcedLogout':           'Sinut on kirjattu ulos.',
+    'login.signInAgain':            'Kirjaudu uudelleen',
+};
+
+const SV: Translations = {
+    'launcher.openPrimaryWindow':   'Öppna primärt fönster',
+    'launcher.openSecondaryWindow': 'Öppna sekundärt fönster',
+    'launcher.accountManagement':   'Kontohantering',
+    'launcher.signOut':             'Logga ut',
+    'launcher.language':            'Språk',
+    'primaryWindow.newCall':        'Nytt samtal',
+    'primaryWindow.newIncident':    'Nytt uppdrag',
+    'footer.normalMode':            'Normal',
+    'login.signingIn':              'Loggar in\u2026',
+    'login.sessionExpired':         'Du har loggats ut.',
+    'login.idleTimeout':            'Du loggades ut på grund av inaktivitet.',
+    'login.maxLifetime':            'Din session har nått sin maximala varaktighet.',
+    'login.forcedLogout':           'Du har loggats ut.',
+    'login.signInAgain':            'Logga in igen',
+};
+
+const LOCALE_MAP: Record<Locale, Translations> = { en: EN, fi: FI, sv: SV };
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the active locale.
+ * Reads from localStorage; defaults to 'en' if absent or unrecognised.
+ */
+export function getLocale(): Locale {
+    const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
+    return (stored !== null && SUPPORTED_LOCALES.has(stored)) ? (stored as Locale) : 'en';
+}
+
+/**
+ * Persists the given locale to localStorage and reloads the page so the
+ * new locale is applied everywhere (acceptable per NFR and UX guidelines).
+ */
+export function setLocale(locale: Locale): void {
+    localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+    location.reload();
+}
+
+/**
+ * Returns the translation for the given key in the active locale.
+ * Falls back to the English string if the key is absent in the active locale.
+ */
+export function t(key: TranslationKey): string {
+    const locale = getLocale();
+    return LOCALE_MAP[locale][key] ?? EN[key];
+}

--- a/Implementation/clients/dispatcher-client/src/ui/LauncherPage.css
+++ b/Implementation/clients/dispatcher-client/src/ui/LauncherPage.css
@@ -108,3 +108,42 @@
     border-top: 1px solid var(--color-bg-border);
     margin: var(--space-xs) 0;
 }
+
+/* Language selector */
+
+.lang-selector {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding-top: var(--space-xs);
+    border-top: 1px solid var(--color-bg-border);
+    width: 100%;
+}
+
+.lang-selector-label {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin-right: var(--space-xs);
+}
+
+.lang-btn {
+    padding: 2px var(--space-sm);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-sm);
+    font-family: inherit;
+    cursor: pointer;
+    border: 1px solid var(--color-bg-border);
+    background: transparent;
+    color: var(--color-text-muted);
+}
+
+.lang-btn:hover:not(:disabled) {
+    border-color: var(--color-accent);
+    color: var(--color-text-primary);
+}
+
+.lang-btn.lang-btn-active {
+    border-color: var(--color-accent);
+    color: var(--color-text-primary);
+    font-weight: 600;
+}

--- a/Implementation/clients/dispatcher-client/src/ui/LauncherPage.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/LauncherPage.ts
@@ -7,6 +7,7 @@ import type { AuthState } from '../auth/AuthState.ts';
 import { SESSION_CHANNEL_NAME } from './windowType.ts';
 import { PRIMARY_WINDOW_OPEN_KEY } from './PrimaryWindow.ts';
 import { SECONDARY_WINDOW_OPEN_KEY } from './SecondaryWindow.ts';
+import { t, getLocale, setLocale, type Locale } from '../i18n/index.ts';
 
 /** Feature string for window.open — no browser chrome, sized for Full HD monitors. */
 const WINDOW_FEATURES = 'width=1920,height=1080,menubar=no,toolbar=no,location=no,status=no';
@@ -107,13 +108,13 @@ export class LauncherPage extends HTMLElement {
         actions.className = 'launcher-actions';
 
         const openPrimaryBtn = this.#makeButton(
-            'Open Primary Window',
+            t('launcher.openPrimaryWindow'),
             'launcher-btn primary-action open-primary-btn',
             () => { this.#openWindow('primary'); },
         );
 
         const openSecondaryBtn = this.#makeButton(
-            'Open Secondary Window',
+            t('launcher.openSecondaryWindow'),
             'launcher-btn primary-action open-secondary-btn',
             () => { this.#openWindow('secondary'); },
         );
@@ -122,13 +123,13 @@ export class LauncherPage extends HTMLElement {
         divider.className = 'launcher-divider';
 
         const accountBtn = this.#makeButton(
-            'Account Management',
+            t('launcher.accountManagement'),
             'launcher-btn',
             () => { this.#openAccountManagement(); },
         );
 
         const signOutBtn = this.#makeButton(
-            'Sign Out',
+            t('launcher.signOut'),
             'launcher-btn launcher-btn-signout',
             () => {
                 // Notify all open dispatcher windows before redirecting so they
@@ -140,7 +141,10 @@ export class LauncherPage extends HTMLElement {
         );
 
         actions.append(openPrimaryBtn, openSecondaryBtn, divider, accountBtn, signOutBtn);
-        card.append(logo, title, usernameEl, actions);
+
+        const langSelector = this.#makeLangSelector();
+
+        card.append(logo, title, usernameEl, actions, langSelector);
         this.#shadow.append(style, card);
     }
 
@@ -291,6 +295,41 @@ export class LauncherPage extends HTMLElement {
             sessionStorage.getItem(PRIMARY_WINDOW_OPEN_KEY) === '1' ||
             sessionStorage.getItem(SECONDARY_WINDOW_OPEN_KEY) === '1'
         );
+    }
+
+    /** Builds the language selector bar (FI / SV / EN toggle buttons). */
+    #makeLangSelector(): HTMLElement {
+        const activeLocale = getLocale();
+
+        const container = document.createElement('div');
+        container.className = 'lang-selector';
+
+        const label = document.createElement('span');
+        label.className = 'lang-selector-label';
+        label.textContent = t('launcher.language');
+        container.appendChild(label);
+
+        const locales: { code: Locale; label: string }[] = [
+            { code: 'fi', label: 'FI' },
+            { code: 'sv', label: 'SV' },
+            { code: 'en', label: 'EN' },
+        ];
+
+        for (const { code, label: btnLabel } of locales) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'lang-btn';
+            btn.textContent = btnLabel;
+            btn.setAttribute('lang', code);
+            if (code === activeLocale) {
+                btn.classList.add('lang-btn-active');
+                btn.setAttribute('aria-current', 'true');
+            }
+            btn.addEventListener('click', () => { setLocale(code); });
+            container.appendChild(btn);
+        }
+
+        return container;
     }
 
     #makeButton(text: string, className: string, onClick: () => void): HTMLButtonElement {

--- a/Implementation/clients/dispatcher-client/src/ui/LoginScreen.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/LoginScreen.ts
@@ -2,17 +2,18 @@
 // Displayed while the OIDC flow is in progress or after a session ends.
 
 import STYLES from './LoginScreen.css?inline';
+import { t, type TranslationKey } from '../i18n/index.ts';
 
 type LoginScreenStatus = 'loading' | 'session-expired' | 'idle-timeout' | 'max-lifetime' | 'forced-logout';
 
-const STATUS_MESSAGES: Record<LoginScreenStatus, string> = {
-    'loading': 'Signing in…',
-    'session-expired': 'You have been signed out.',
-    'idle-timeout': 'You were signed out due to inactivity.',
-    'max-lifetime': 'Your session has reached its maximum duration.',
+const STATUS_KEYS: Record<LoginScreenStatus, TranslationKey> = {
+    'loading':        'login.signingIn',
+    'session-expired': 'login.sessionExpired',
+    'idle-timeout':   'login.idleTimeout',
+    'max-lifetime':   'login.maxLifetime',
     // Set by AppShell when the server revokes the session (back-channel logout
     // or admin termination) or when OIDC discovery fails.
-    'forced-logout': 'You have been signed out.',
+    'forced-logout':  'login.forcedLogout',
 };
 
 /** Event dispatched when the user clicks "Sign in again". Bubbles through the DOM. */
@@ -86,7 +87,7 @@ export class LoginScreen extends HTMLElement {
 
         this.#signInButtonEl = document.createElement('button');
         this.#signInButtonEl.className = 'sign-in-button';
-        this.#signInButtonEl.textContent = 'Sign in again';
+        this.#signInButtonEl.textContent = t('login.signInAgain');
         this.#signInButtonEl.addEventListener('click', () => {
             this.dispatchEvent(new LoginRequestedEvent());
         });
@@ -104,7 +105,8 @@ export class LoginScreen extends HTMLElement {
         const status = (this.getAttribute('status') ?? 'loading') as LoginScreenStatus;
         const isLoading = status === 'loading';
 
-        this.#messageEl.textContent = STATUS_MESSAGES[status] ?? STATUS_MESSAGES['loading'];
+        const key = STATUS_KEYS[status] ?? STATUS_KEYS['loading'];
+        this.#messageEl.textContent = t(key);
         this.#loadingIndicatorEl.style.display = isLoading ? 'block' : 'none';
         this.#signInButtonEl.style.display = isLoading ? 'none' : 'inline-block';
     }

--- a/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
@@ -3,6 +3,7 @@
 
 import STYLES from './PrimaryWindow.css?inline';
 import { WindowHeader, WindowFooter } from './WindowChrome.ts';
+import { t } from '../i18n/index.ts';
 
 /** localStorage key set by this window so the launcher can detect it is open. */
 export const PRIMARY_WINDOW_OPEN_KEY = 'idispatch:window:primary' as const;
@@ -42,13 +43,13 @@ export class PrimaryWindow extends HTMLElement {
         const newCallBtn = document.createElement('button');
         newCallBtn.type = 'button';
         newCallBtn.className = 'header-action-btn';
-        newCallBtn.textContent = 'New Call';
+        newCallBtn.textContent = t('primaryWindow.newCall');
         newCallBtn.slot = 'actions';
 
         const newIncidentBtn = document.createElement('button');
         newIncidentBtn.type = 'button';
         newIncidentBtn.className = 'header-action-btn';
-        newIncidentBtn.textContent = 'New Incident';
+        newIncidentBtn.textContent = t('primaryWindow.newIncident');
         newIncidentBtn.slot = 'actions';
 
         header.append(newCallBtn, newIncidentBtn);

--- a/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
@@ -1,6 +1,7 @@
 // Shared header and footer Web Components used by both the primary and secondary windows.
 
 import STYLES from './WindowChrome.css?inline';
+import { t } from '../i18n/index.ts';
 
 const HELSINKI_TZ = 'Europe/Helsinki';
 
@@ -141,7 +142,7 @@ export class WindowFooter extends HTMLElement {
         const modeEl = document.createElement('span');
         modeEl.className = 'footer-right';
         // Placeholder — actual degraded-mode detection is added in a later iteration
-        modeEl.textContent = 'Normal';
+        modeEl.textContent = t('footer.normalMode');
 
         this.#shadow.append(style, this.#usernameEl, modeEl);
     }


### PR DESCRIPTION
Closes #22

## Summary

- Introduces `src/i18n/index.ts` — a lightweight i18n module with translation tables for English (`en`), Finnish (`fi`), and Swedish (`sv`). Exposes `t(key)`, `getLocale()`, and `setLocale(locale)`. Locale is persisted in `localStorage`; changing it triggers a full page reload (acceptable per NFR and UX guidelines). English is the fallback when a key is absent in the active locale.
- Replaces all hard-coded UI strings in `LoginScreen`, `PrimaryWindow`, `WindowChrome`, and `LauncherPage` with `t()` calls.
- Adds a language selector (FI / SV / EN toggle) to the launcher card. The active locale is marked visually (`lang-btn-active` CSS class) and accessibly (`aria-current`).

## Test plan

- `e2e/i18n.spec.ts` — 8 new E2E tests covering: English default, unrecognised-locale fallback, Finnish and Swedish label rendering across launcher and primary window, locale persistence across reload, language selector rendering and state, locale switching via the selector, and localised login screen strings (English and Finnish).
- `e2e/launcher.spec.ts` — existing button-label test updated to explicitly clear the locale from `localStorage` before running, with a comment explaining the locale dependency.