### PR TITLE
Dispatcher Client: update header and footer look and feel to match UI mockup

### DIFF
--- a/Implementation/clients/dispatcher-client/src/styles/tokens.css
+++ b/Implementation/clients/dispatcher-client/src/styles/tokens.css
@@ -42,10 +42,10 @@
     --radius-md: 6px;
 
     /* Window chrome */
-    --color-header-bg:     #2d2d30;   /* brighter than --color-bg-surface, VS Code title bar tone */
-    --color-header-border: #3e3e42;
-    --color-footer-bg:     #1a1a1c;   /* darker than --color-bg-base for status-bar feel */
-    --color-footer-border: #333336;
+    --color-header-bg:     #3c3c3c;
+    --color-header-border: #222222;
+    --color-footer-bg:     #007acc;   /* VS Code-style blue status bar */
+    --color-footer-border: #005fa3;
     --color-header-text:   #e8e8e8;
     --color-header-muted:  #b0b0b0;
     --height-header:       48px;

--- a/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.css
+++ b/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.css
@@ -18,3 +18,34 @@
     overflow: hidden;
     /* Operational content (call/incident columns) will be placed here */
 }
+
+/* ---- Layout preset buttons (header-right slot) ---- */
+
+.layout-btn {
+    display: inline-flex;
+    gap: 2px;
+    padding: 4px 6px;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    border: none;
+    align-items: center;
+}
+
+.layout-btn:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.layout-btn.active {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.layout-bar {
+    height: 16px;
+    background: #888888;
+    border-radius: 1px;
+}
+
+.layout-btn.active .layout-bar {
+    background: #0078d4;
+}

--- a/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
@@ -54,6 +54,9 @@ export class PrimaryWindow extends HTMLElement {
 
         header.append(newCallBtn, newIncidentBtn);
 
+        const layoutButtons = this.#makeLayoutButtons();
+        header.append(...layoutButtons);
+
         const body = document.createElement('div');
         body.className = 'window-body';
 
@@ -65,6 +68,31 @@ export class PrimaryWindow extends HTMLElement {
 
     disconnectedCallback(): void {
         this.#unregisterOpenFlag();
+    }
+
+    /** Builds the four layout-preset buttons for the header-right slot. */
+    #makeLayoutButtons(): HTMLButtonElement[] {
+        const presets: { bars: number[]; title: string }[] = [
+            { bars: [6, 4, 4], title: 'Call focused (Ctrl+Shift+1)' },
+            { bars: [4, 4, 4], title: 'Equal columns (Ctrl+Shift+2)' },
+            { bars: [4, 6, 4], title: 'Incident focused (Ctrl+Shift+3)' },
+            { bars: [4, 4, 6], title: 'Lists focused (Ctrl+Shift+4)' },
+        ];
+
+        return presets.map((preset, i) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = i === 1 ? 'layout-btn active' : 'layout-btn';
+            btn.title = preset.title;
+            btn.slot = 'layout';
+            for (const w of preset.bars) {
+                const bar = document.createElement('span');
+                bar.className = 'layout-bar';
+                bar.style.width = `${w}px`;
+                btn.appendChild(bar);
+            }
+            return btn;
+        });
     }
 
     #registerOpenFlag(): void {

--- a/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/PrimaryWindow.ts
@@ -73,12 +73,14 @@ export class PrimaryWindow extends HTMLElement {
     /** Builds the four layout-preset buttons for the header-right slot. */
     #makeLayoutButtons(): HTMLButtonElement[] {
         const presets: { bars: number[]; title: string }[] = [
-            { bars: [6, 4, 4], title: 'Call focused (Ctrl+Shift+1)' },
-            { bars: [4, 4, 4], title: 'Equal columns (Ctrl+Shift+2)' },
-            { bars: [4, 6, 4], title: 'Incident focused (Ctrl+Shift+3)' },
-            { bars: [4, 4, 6], title: 'Lists focused (Ctrl+Shift+4)' },
+            { bars: [10, 4, 4], title: 'Call focused (Ctrl+Shift+1)' },
+            { bars: [6, 6, 6],  title: 'Equal columns (Ctrl+Shift+2)' },
+            { bars: [4, 10, 4], title: 'Incident focused (Ctrl+Shift+3)' },
+            { bars: [4, 4, 10], title: 'Lists focused (Ctrl+Shift+4)' },
         ];
 
+        // Buttons are visual-only placeholders; click handlers will be added
+        // when layout switching behaviour is implemented.
         return presets.map((preset, i) => {
             const btn = document.createElement('button');
             btn.type = 'button';

--- a/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.css
+++ b/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.css
@@ -18,3 +18,34 @@
     overflow: hidden;
     /* Map and unit dashboard will be placed here */
 }
+
+/* ---- Layout preset buttons (header-right slot) ---- */
+
+.layout-btn-secondary {
+    display: inline-flex;
+    gap: 2px;
+    padding: 4px 6px;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    border: none;
+    align-items: center;
+}
+
+.layout-btn-secondary:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.layout-btn-secondary.active {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.layout-block {
+    height: 14px;
+    background: #888888;
+    border-radius: 1px;
+}
+
+.layout-btn-secondary.active .layout-block {
+    background: #0078d4;
+}

--- a/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.ts
@@ -37,6 +37,9 @@ export class SecondaryWindow extends HTMLElement {
 
         const header = document.createElement(WindowHeader.TAG) as WindowHeader;
 
+        const layoutButtons = this.#makeLayoutButtons();
+        header.append(...layoutButtons);
+
         const body = document.createElement('div');
         body.className = 'window-body';
 
@@ -48,6 +51,32 @@ export class SecondaryWindow extends HTMLElement {
 
     disconnectedCallback(): void {
         this.#unregisterOpenFlag();
+    }
+
+    /** Builds the five layout-preset buttons for the header-right slot. */
+    #makeLayoutButtons(): HTMLButtonElement[] {
+        const presets: { blocks: number[]; title: string }[] = [
+            { blocks: [20],     title: 'Map only (Ctrl+Shift+1)' },
+            { blocks: [14, 7],  title: 'Map 2:1 Dashboard (Ctrl+Shift+2)' },
+            { blocks: [10, 10], title: 'Map 1:1 Dashboard (Ctrl+Shift+3)' },
+            { blocks: [7, 14],  title: 'Map 1:2 Dashboard (Ctrl+Shift+4)' },
+            { blocks: [20],     title: 'Dashboard only (Ctrl+Shift+5)' },
+        ];
+
+        return presets.map((preset, i) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = i === 2 ? 'layout-btn-secondary active' : 'layout-btn-secondary';
+            btn.title = preset.title;
+            btn.slot = 'layout';
+            for (const w of preset.blocks) {
+                const block = document.createElement('span');
+                block.className = 'layout-block';
+                block.style.width = `${w}px`;
+                btn.appendChild(block);
+            }
+            return btn;
+        });
     }
 
     #registerOpenFlag(): void {

--- a/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/SecondaryWindow.ts
@@ -56,13 +56,15 @@ export class SecondaryWindow extends HTMLElement {
     /** Builds the five layout-preset buttons for the header-right slot. */
     #makeLayoutButtons(): HTMLButtonElement[] {
         const presets: { blocks: number[]; title: string }[] = [
-            { blocks: [20],     title: 'Map only (Ctrl+Shift+1)' },
+            { blocks: [18, 3],  title: 'Map only (Ctrl+Shift+1)' },
             { blocks: [14, 7],  title: 'Map 2:1 Dashboard (Ctrl+Shift+2)' },
             { blocks: [10, 10], title: 'Map 1:1 Dashboard (Ctrl+Shift+3)' },
             { blocks: [7, 14],  title: 'Map 1:2 Dashboard (Ctrl+Shift+4)' },
-            { blocks: [20],     title: 'Dashboard only (Ctrl+Shift+5)' },
+            { blocks: [3, 18],  title: 'Dashboard only (Ctrl+Shift+5)' },
         ];
 
+        // Buttons are visual-only placeholders; click handlers will be added
+        // when layout switching behaviour is implemented.
         return presets.map((preset, i) => {
             const btn = document.createElement('button');
             btn.type = 'button';

--- a/Implementation/clients/dispatcher-client/src/ui/WindowChrome.css
+++ b/Implementation/clients/dispatcher-client/src/ui/WindowChrome.css
@@ -62,6 +62,13 @@
     flex-shrink: 0;
 }
 
+.header-app-name {
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--color-header-text);
+    white-space: nowrap;
+}
+
 .header-clock {
     font-size: var(--font-size-sm);
     color: var(--color-header-muted);
@@ -71,9 +78,9 @@
 }
 
 ::slotted(.header-action-btn) {
-    background: var(--color-bg-surface);
-    border: 1px solid var(--color-bg-border);
-    color: var(--color-header-text);
+    background: var(--color-accent);
+    border: 1px solid var(--color-accent);
+    color: #ffffff;
     border-radius: var(--radius-sm);
     padding: 3px var(--space-sm);
     font-size: var(--font-size-sm);
@@ -83,7 +90,8 @@
 }
 
 ::slotted(.header-action-btn:hover) {
-    background: var(--color-bg-base);
+    background: var(--color-accent-hover);
+    border-color: var(--color-accent-hover);
 }
 
 ::slotted(.header-action-btn:active) {
@@ -102,7 +110,7 @@
     border-top: 1px solid var(--color-footer-border);
     font-family: var(--font-family-ui);
     font-size: var(--font-size-sm);
-    color: var(--color-text-secondary);
+    color: #ffffff;
     flex-shrink: 0;
     padding: 0 var(--space-md);
     box-sizing: border-box;
@@ -117,5 +125,15 @@
 
 .footer-right {
     flex: 0 0 auto;
-    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.mode-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #4caf50;
+    flex-shrink: 0;
 }

--- a/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
+++ b/Implementation/clients/dispatcher-client/src/ui/WindowChrome.ts
@@ -63,12 +63,16 @@ export class WindowHeader extends HTMLElement {
         logo.textContent = 'iD';
         logo.setAttribute('aria-hidden', 'true');
 
+        const appName = document.createElement('span');
+        appName.className = 'header-app-name';
+        appName.textContent = 'iDispatchX';
+
         this.#clockEl = document.createElement('span');
         this.#clockEl.className = 'header-clock';
         this.#clockEl.setAttribute('aria-live', 'off');
         this.#clockEl.setAttribute('aria-label', 'Current date and time');
 
-        left.append(logo, this.#clockEl);
+        left.append(logo, appName, this.#clockEl);
 
         // Center: named slot for caller-provided action buttons
         const center = document.createElement('div');
@@ -78,9 +82,13 @@ export class WindowHeader extends HTMLElement {
         actionsSlot.name = 'actions';
         center.appendChild(actionsSlot);
 
-        // Right: layout customization (placeholder — buttons added in a later iteration)
+        // Right: named slot for caller-provided layout-preset buttons
         const right = document.createElement('div');
         right.className = 'header-right';
+
+        const layoutSlot = document.createElement('slot');
+        layoutSlot.name = 'layout';
+        right.appendChild(layoutSlot);
 
         this.#shadow.append(style, left, center, right);
 
@@ -141,8 +149,16 @@ export class WindowFooter extends HTMLElement {
 
         const modeEl = document.createElement('span');
         modeEl.className = 'footer-right';
+
+        const modeDot = document.createElement('span');
+        modeDot.className = 'mode-dot';
+        modeDot.setAttribute('aria-hidden', 'true');
+
+        const modeText = document.createElement('span');
         // Placeholder — actual degraded-mode detection is added in a later iteration
-        modeEl.textContent = t('footer.normalMode');
+        modeText.textContent = t('footer.normalMode');
+
+        modeEl.append(modeDot, modeText);
 
         this.#shadow.append(style, this.#usernameEl, modeEl);
     }


### PR DESCRIPTION
Closes #35

## Summary

- Update color tokens to match the mockup: header bg `#3c3c3c`, header border `#222222`, footer bg `#007acc` (VS Code-style blue status bar)
- Add "iDispatchX" app name label next to the brand logo in the header
- Expose a named `layout` slot in `WindowHeader` so primary and secondary windows can inject their own layout-preset buttons
- Add mode indicator dot (green circle) to the footer
- Update "New Call"/"New Incident" action buttons to primary blue (matching the mockup's `btn-primary` style)
- Update footer text color to white for contrast against the new blue background
- Primary window injects 4 vertical-bar layout-preset buttons (Call focused / Equal / Incident focused / Lists focused, `Ctrl+Shift+1–4`)
- Secondary window injects 5 block layout-preset buttons (Map only / 2:1 / 1:1 / 1:2 / Dashboard only, `Ctrl+Shift+1–5`)

Layout buttons are purely visual — no layout switching behaviour is wired up.

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 42 existing E2E tests pass (`npm test`)
- [x] Visually verify header shows logo + "iDispatchX" + clock in both windows
- [x] Visually verify header background is lighter (`#3c3c3c`) than before
- [x] Visually verify "New Call" / "New Incident" buttons are blue
- [x] Visually verify layout-preset buttons appear in the header right area
- [x] Visually verify footer is blue (`#007acc`) with white text and a green mode dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)