### PR TITLE
Fix PostGIS readiness during Maven build

### DIFF
--- a/Implementation/servers/cad-server/src/test/java/net/pkhapps/idispatchx/cad/adapter/secondary/snapshot/FileBasedSnapshotAdapterTest.java
+++ b/Implementation/servers/cad-server/src/test/java/net/pkhapps/idispatchx/cad/adapter/secondary/snapshot/FileBasedSnapshotAdapterTest.java
@@ -1,6 +1,5 @@
 package net.pkhapps.idispatchx.cad.adapter.secondary.snapshot;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import net.pkhapps.idispatchx.cad.adapter.secondary.wal.DomainEventSerializer;
 import net.pkhapps.idispatchx.cad.adapter.secondary.wal.JsonDomainEventSerializer;
 import net.pkhapps.idispatchx.cad.adapter.secondary.wal.SmileDomainEventSerializer;
@@ -27,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import tools.jackson.databind.node.JsonNodeFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/Implementation/shared/gis-database/pom.xml
+++ b/Implementation/shared/gis-database/pom.xml
@@ -82,12 +82,7 @@
                                     <port>db.port:5432</port>
                                 </ports>
                                 <wait>
-                                    <tcp>
-                                        <host>localhost</host>
-                                        <ports>
-                                            <port>5432</port>
-                                        </ports>
-                                    </tcp>
+                                    <log>(?s).*PostgreSQL init process complete; ready for start up\..*database system is ready to accept connections.*</log>
                                     <time>60000</time>
                                 </wait>
                             </run>


### PR DESCRIPTION
## Summary
- wait for the PostGIS container's final startup log before running Flyway/jOOQ codegen
- fix a stale Jackson 2 test import in the CAD snapshot adapter test

## Verification
- ./mvnw package