### PR TITLE
Fix GIS raster importer memory usage

### DIFF
--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/raster/RasterTileImporter.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/raster/RasterTileImporter.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -63,31 +62,37 @@ public final class RasterTileImporter {
             return 0;
         }
 
-        BufferedImage source;
-        try {
-            source = ImageIO.read(pngFile.toFile());
+        var imageIndex = 0;
+        int sourceWidth;
+        int sourceHeight;
+        try (var imageInput = ImageIO.createImageInputStream(pngFile.toFile())) {
+            if (imageInput == null) {
+                LOG.warn("Skipping {}: cannot open image input", pngFile.getFileName());
+                return 0;
+            }
+            var readers = ImageIO.getImageReaders(imageInput);
+            if (!readers.hasNext()) {
+                LOG.warn("Skipping {}: unsupported image format", pngFile.getFileName());
+                return 0;
+            }
+
+            var reader = readers.next();
+            try {
+                reader.setInput(imageInput, true, true);
+                sourceWidth = reader.getWidth(imageIndex);
+                sourceHeight = reader.getHeight(imageIndex);
+            } finally {
+                reader.dispose();
+            }
         } catch (IOException e) {
             LOG.warn("Skipping {}: cannot read image: {}", pngFile.getFileName(), e.getMessage());
             return 0;
         }
-        if (source == null) {
-            LOG.warn("Skipping {}: unsupported image format", pngFile.getFileName());
-            return 0;
-        }
-
-        // Convert indexed color to ARGB
-        if (source.getType() == BufferedImage.TYPE_BYTE_INDEXED) {
-            var converted = new BufferedImage(source.getWidth(), source.getHeight(), BufferedImage.TYPE_INT_ARGB);
-            var g = converted.createGraphics();
-            g.drawImage(source, 0, 0, null);
-            g.dispose();
-            source = converted;
-        }
 
         var ulX = worldData.ulCornerX();
         var ulY = worldData.ulCornerY();
-        var lrX = ulX + source.getWidth() * worldData.pixelWidth();
-        var lrY = ulY + source.getHeight() * worldData.pixelHeight();
+        var lrX = ulX + sourceWidth * worldData.pixelWidth();
+        var lrY = ulY + sourceHeight * worldData.pixelHeight();
 
         LOG.info("Importing {}: zoom={}, pixelSize={}m, bounds=({}, {}) to ({}, {}), tiles={}x{}",
                 pngFile.getFileName(), zoom, worldData.pixelWidth(),
@@ -97,11 +102,27 @@ public final class RasterTileImporter {
 
         var start = System.currentTimeMillis();
         int tilesWritten;
-        try {
-            tilesWritten = TileExtractor.extract(source, zoom, ulX, ulY,
-                    worldData.pixelWidth(), worldData.pixelHeight(), tileWriter::write);
+        try (var imageInput = ImageIO.createImageInputStream(pngFile.toFile())) {
+            if (imageInput == null) {
+                LOG.warn("Skipping {}: cannot open image input", pngFile.getFileName());
+                return 0;
+            }
+            var readers = ImageIO.getImageReaders(imageInput);
+            if (!readers.hasNext()) {
+                LOG.warn("Skipping {}: unsupported image format", pngFile.getFileName());
+                return 0;
+            }
+
+            var reader = readers.next();
+            try {
+                reader.setInput(imageInput, true, true);
+                tilesWritten = TileExtractor.extract(reader, imageIndex, zoom, ulX, ulY,
+                        worldData.pixelWidth(), worldData.pixelHeight(), tileWriter::write);
+            } finally {
+                reader.dispose();
+            }
         } catch (IOException e) {
-            LOG.error("Error writing tiles for {}: {}", pngFile.getFileName(), e.getMessage());
+            LOG.error("Error reading or writing tiles for {}: {}", pngFile.getFileName(), e.getMessage());
             return 0;
         }
 

--- a/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/raster/TileExtractor.java
+++ b/Implementation/tools/gis-data-importer/src/main/java/net/pkhapps/idispatchx/gis/importer/raster/TileExtractor.java
@@ -1,5 +1,7 @@
 package net.pkhapps.idispatchx.gis.importer.raster;
 
+import javax.imageio.ImageReader;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 
@@ -46,6 +48,67 @@ public final class TileExtractor {
                               double pixelWidth, double pixelHeight, TileConsumer consumer) throws IOException {
         var srcWidth = source.getWidth();
         var srcHeight = source.getHeight();
+        return extract(zoom, ulX, ulY, pixelWidth, pixelHeight, srcWidth, srcHeight,
+                (clampedSrcX, clampedSrcY, clampedSrcEndX, clampedSrcEndY, destX, destY, destEndX, destEndY) -> {
+                    var tile = new BufferedImage(TileMatrixSet.TILE_SIZE, TileMatrixSet.TILE_SIZE,
+                            BufferedImage.TYPE_INT_ARGB);
+                    var g = tile.createGraphics();
+                    try {
+                        g.drawImage(source,
+                                destX, destY, destEndX, destEndY,
+                                clampedSrcX, clampedSrcY, clampedSrcEndX, clampedSrcEndY,
+                                null);
+                    } finally {
+                        g.dispose();
+                    }
+                    return tile;
+                }, consumer);
+    }
+
+    /**
+     * Extracts tiles from an image reader and passes each non-empty tile to the consumer.
+     * The reader is asked for only the source region needed for each output tile, which keeps
+     * peak heap usage bounded for large source rasters.
+     *
+     * @param reader      image reader positioned at the PNG input
+     * @param imageIndex  image index to read, usually 0
+     * @param zoom        the zoom level
+     * @param ulX         upper-left corner easting (edge of first pixel)
+     * @param ulY         upper-left corner northing (edge of first pixel)
+     * @param pixelWidth  pixel width in meters (positive)
+     * @param pixelHeight pixel height in meters (negative)
+     * @param consumer    consumer for non-empty extracted tiles
+     * @return number of tiles passed to the consumer
+     * @throws IOException if image reading or the consumer throws an IOException
+     */
+    public static int extract(ImageReader reader, int imageIndex, int zoom, double ulX, double ulY,
+                              double pixelWidth, double pixelHeight, TileConsumer consumer) throws IOException {
+        var srcWidth = reader.getWidth(imageIndex);
+        var srcHeight = reader.getHeight(imageIndex);
+        return extract(zoom, ulX, ulY, pixelWidth, pixelHeight, srcWidth, srcHeight,
+                (clampedSrcX, clampedSrcY, clampedSrcEndX, clampedSrcEndY, destX, destY, destEndX, destEndY) -> {
+                    var param = reader.getDefaultReadParam();
+                    var width = clampedSrcEndX - clampedSrcX;
+                    var height = clampedSrcEndY - clampedSrcY;
+                    param.setSourceRegion(new Rectangle(clampedSrcX, clampedSrcY, width, height));
+                    var region = reader.read(imageIndex, param);
+
+                    var tile = new BufferedImage(TileMatrixSet.TILE_SIZE, TileMatrixSet.TILE_SIZE,
+                            BufferedImage.TYPE_INT_ARGB);
+                    var g = tile.createGraphics();
+                    try {
+                        g.drawImage(region, destX, destY, destEndX, destEndY, 0, 0, width, height, null);
+                    } finally {
+                        g.dispose();
+                        region.flush();
+                    }
+                    return tile;
+                }, consumer);
+    }
+
+    private static int extract(int zoom, double ulX, double ulY, double pixelWidth, double pixelHeight,
+                               int srcWidth, int srcHeight, TileRenderer tileRenderer,
+                               TileConsumer consumer) throws IOException {
         var lrX = ulX + srcWidth * pixelWidth;
         var lrY = ulY + srcHeight * pixelHeight; // pixelHeight is negative, so lrY < ulY
         var absPixelHeight = Math.abs(pixelHeight);
@@ -77,32 +140,30 @@ public final class TileExtractor {
                     continue;
                 }
 
-                // Create 256x256 transparent ARGB tile
-                var tile = new BufferedImage(TileMatrixSet.TILE_SIZE, TileMatrixSet.TILE_SIZE,
-                        BufferedImage.TYPE_INT_ARGB);
-                var g = tile.createGraphics();
-                try {
-                    // Compute destination pixel positions on the tile
-                    var destX = (int) Math.round((clampedSrcX - srcX) * pixelWidth / pixelWidth);
-                    var destY = (int) Math.round((clampedSrcY - srcY) * absPixelHeight / absPixelHeight);
-                    var destEndX = destX + (clampedSrcEndX - clampedSrcX);
-                    var destEndY = destY + (clampedSrcEndY - clampedSrcY);
+                // Compute destination pixel positions on the tile
+                var destX = (int) Math.round((clampedSrcX - srcX) * pixelWidth / pixelWidth);
+                var destY = (int) Math.round((clampedSrcY - srcY) * absPixelHeight / absPixelHeight);
+                var destEndX = destX + (clampedSrcEndX - clampedSrcX);
+                var destEndY = destY + (clampedSrcEndY - clampedSrcY);
 
-                    g.drawImage(source,
-                            destX, destY, destEndX, destEndY,
-                            clampedSrcX, clampedSrcY, clampedSrcEndX, clampedSrcEndY,
-                            null);
-                } finally {
-                    g.dispose();
-                }
+                var tile = tileRenderer.render(clampedSrcX, clampedSrcY, clampedSrcEndX, clampedSrcEndY,
+                        destX, destY, destEndX, destEndY);
 
                 if (!isFullyTransparent(tile)) {
                     consumer.accept(new ExtractedTile(new TileMatrixSet.TileCoordinate(zoom, row, col), tile));
                     count++;
+                } else {
+                    tile.flush();
                 }
             }
         }
         return count;
+    }
+
+    @FunctionalInterface
+    private interface TileRenderer {
+        BufferedImage render(int clampedSrcX, int clampedSrcY, int clampedSrcEndX, int clampedSrcEndY,
+                             int destX, int destY, int destEndX, int destEndY) throws IOException;
     }
 
     private static boolean isFullyTransparent(BufferedImage image) {

--- a/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/raster/TileExtractorTest.java
+++ b/Implementation/tools/gis-data-importer/src/test/java/net/pkhapps/idispatchx/gis/importer/raster/TileExtractorTest.java
@@ -1,15 +1,21 @@
 package net.pkhapps.idispatchx.gis.importer.raster;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class TileExtractorTest {
+
+    @TempDir
+    Path tempDir;
 
     /**
      * Creates a solid-color ARGB image of the given size.
@@ -133,5 +139,44 @@ class TileExtractorTest {
         var count = TileExtractor.extract(source, 14, bounds.west(), bounds.north(), 0.5, -0.5, tiles::add);
 
         assertEquals(tiles.size(), count);
+    }
+
+    // === Region reading extraction ===
+
+    @Test
+    void extract_imageReader_producesSameTilesAsBufferedImage() throws IOException {
+        var bounds = TileMatrixSet.tileBounds(14, 13364, 6035);
+        var source = new BufferedImage(512, 512, BufferedImage.TYPE_INT_ARGB);
+        var g = source.createGraphics();
+        g.setColor(Color.RED);
+        g.fillRect(0, 0, 256, 256);
+        g.setColor(Color.BLUE);
+        g.fillRect(256, 256, 256, 256);
+        g.dispose();
+
+        var pngPath = tempDir.resolve("source.png");
+        ImageIO.write(source, "png", pngPath.toFile());
+
+        var bufferedTiles = new ArrayList<TileExtractor.ExtractedTile>();
+        TileExtractor.extract(source, 14, bounds.west(), bounds.north(), 0.5, -0.5, bufferedTiles::add);
+
+        var readerTiles = new ArrayList<TileExtractor.ExtractedTile>();
+        try (var imageInput = ImageIO.createImageInputStream(pngPath.toFile())) {
+            var readers = ImageIO.getImageReaders(imageInput);
+            assertTrue(readers.hasNext());
+            var reader = readers.next();
+            try {
+                reader.setInput(imageInput, true, true);
+                TileExtractor.extract(reader, 0, 14, bounds.west(), bounds.north(), 0.5, -0.5, readerTiles::add);
+            } finally {
+                reader.dispose();
+            }
+        }
+
+        assertEquals(bufferedTiles.size(), readerTiles.size());
+        for (var i = 0; i < bufferedTiles.size(); i++) {
+            assertEquals(bufferedTiles.get(i).coordinate(), readerTiles.get(i).coordinate());
+            assertEquals(bufferedTiles.get(i).image().getRGB(128, 128), readerTiles.get(i).image().getRGB(128, 128));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid decoding entire raster PNGs before tile extraction
- add ImageReader-backed region extraction for raster tiles
- keep the existing BufferedImage extraction path and cover the new path with tests

Closes #41

## Tests
- ./mvnw -pl tools/gis-data-importer test